### PR TITLE
Fix prefix-cache accounting: avail_size() unit + storage_cache_evicted_req tree

### DIFF
--- a/serving/core/memory_model.py
+++ b/serving/core/memory_model.py
@@ -348,9 +348,9 @@ class MemoryModel():
             return 0
         
         if device == Device.NPU:
-            return self.npu_prefix_cache.avail_size() * self._bytes_per_token
+            return self.npu_prefix_cache.avail_size()
         elif device == Device.CPU or device == Device.CXL:
-            return self.second_tier_prefix_cache.avail_size() * self._bytes_per_token
+            return self.second_tier_prefix_cache.avail_size()
         else:
             raise RuntimeError(f"[MemoryModel] [node_id={self.node_id},inst={self.instance_id}] Trying to get available size of prefix cache in unsupported device {device}")
     
@@ -360,7 +360,7 @@ class MemoryModel():
         if self.enable_prefix_caching:
             new_last_node = self.second_tier_prefix_cache.cache_unfinished_req(req, update=False) # do not update hit counts
             # should lock evicted kv cache in cpu
-            self.npu_prefix_cache.inc_lock_ref(new_last_node)
+            self.second_tier_prefix_cache.inc_lock_ref(new_last_node)
             req.cpu_last_node = new_last_node
             self.apply_kv_cache_events()
 


### PR DESCRIPTION
## Summary

Rebased version of #25 onto current main. The original PR is conflicting because the file moved from `inference_serving/memory_model.py` to `serving/core/memory_model.py` in v1.1.0; the same 4-line fix applies cleanly at the new path.

Two bugs fixed (both authored by @shermanjlim — original commit preserved):

- **`avail_size()` returns bytes twice.** `RadixCache.avail_size()` already returns bytes (`capacity − total_memory_usage()`), so `MemoryModel.avail_size()` multiplying by `_bytes_per_token` again produced a meaninglessly large value. Scheduler decisions based on `avail_size + evictable_size` were under-conservative even at TP=1.
- **`storage_cache_evicted_req` locked the wrong tree.** It called `npu_prefix_cache.inc_lock_ref(new_last_node)` on a node belonging to the *second-tier* prefix tree. Walking parents from a foreign-tree node never reaches `npu_prefix_cache.root_node`, ultimately dereferencing `None` and crashing the simulator when evicting from NPU to CPU/CXL storage with prefix caching on.

Supersedes #25 — will close manually after merge. Thanks @shermanjlim for the fix!

## Test plan
- [x] `python -m ast` syntax check on `serving/core/memory_model.py`
- [x] Empirical reproduction of both bugs via standalone script (verified `avail_size()` returns bytes already; verified `inc_lock_ref` on foreign tree crashes with `AttributeError`)
- [x] `bench validate` smoke run (optional — accounting fix shouldn't change observed throughput/latency)