### PR TITLE
Memory accounting fixes: evict overshoot, offload alignment, PP weight, hardcoded constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,155 @@
 All notable changes to this project are documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [Unreleased]
+
+### Added
+- Public Docusaurus 3 documentation site at
+  [llmservingsim.ai](https://llmservingsim.ai), built from `docs/` and
+  deployed via GitHub Actions Pages. Replaces the old `docs/index.html`
+  placeholder and shifts long-form content (CLI flag tables, dataset
+  schema, profiler walkthroughs, validation plots, etc.) off the README.
+  The repo's `README.md` is now a minimal front door (About / Getting
+  Started / Publications / Citation) that links to the website. The
+  `README and docs split` policy is documented in `AGENTS.md` /
+  `CLAUDE.md`.
+- Local search on the docs site via
+  `@easyops-cn/docusaurus-search-local`. Indexes all `/docs/*` and
+  top-level page routes (Contact, Changelog) at build time. Access via
+  the navbar input or Ctrl/Cmd-K once the production build runs (dev
+  mode does not generate the index — `pnpm build && pnpm serve` to test
+  locally).
+- Module helper `full_cluster_kv_bytes_per_token(model, fp, kv_cache_dtype)`
+  in `serving/core/memory_model.py`. Computes full-cluster KV bytes per
+  token directly from a HuggingFace-style config, avoiding the per-rank
+  floor-division roundoff in `MemoryModel.get_kv(1) * num_npus`. Used by
+  `__main__.py` to size shared prefix pools at startup, before any
+  `MemoryModel` exists.
+
+### Changed
+- Trace-level PP modeling write-up overhauled in
+  `docs/docs/simulator/parallelism-mechanics.md` — explicitly describes
+  the Chakra layer split + `COMM_SEND` / `COMM_RECV` between stages,
+  with a stage-split figure. Replaces the previous
+  "scheduling-only / lower bound" framing which underdescribed what
+  the simulator actually models.
+- `--expert-routing-policy` default documented as `BALANCED`
+  everywhere (expert-parallel example, troubleshooting,
+  trace-generation, `AGENTS.md`) — the earlier docs referenced a
+  non-existent `COPY` default. `CUSTOM` listed under both request- and
+  expert-routing options; `--enable-block-copy` decoupled from routing
+  policy in the docs.
+- `LOAD` request-routing scoring (`waiting * 4 + running`) documented
+  in the multi-instance example. Policy lists reformatted into bullets
+  across affected pages.
+- `MemoryModel.get_weight` now divides the transformer-block weight by
+  `pp_size` (heaviest-rank conservative bound:
+  `embedding + n_layer//pp × per_block + final_layernorm + lm_head`).
+  Required adding a `pp_size` parameter to `MemoryModel.__init__`
+  (threaded through from `Scheduler`). PP=1 behavior unchanged — fix
+  only affects future PP > 1 runs (no current cluster config exercises
+  PP > 1).
+- `MemoryModel.apply_kv_cache_events` now drains the second-tier event
+  queue for CXL prefix storage and CPU + prefix-sharing modes (in
+  addition to the previously-handled CPU non-sharing case). The CPU
+  non-sharing branch keeps bridging events into `cpu_used`; the other
+  paths just drain the queue (no accounting impact — pool memory usage
+  is already tracked via `total_size * kv_size` in `total_memory_usage`).
+  Prevents unbounded growth of the event queue over the simulation
+  lifetime.
+
+### Fixed
+- Chunked prefill double-counted prefix-cache hits. In
+  `schedule_with_prefix`, `chunk_size = original_input - num_computed_tokens`
+  already excludes prefix-cached tokens (because `num_computed_tokens`
+  is bumped to `prefix_cache_hit` on the first `prefix_match`). The
+  scheduler then accumulated `hit_len += prefix_hit` on top of that,
+  and `_build_batch_ctx` (trace_generator.py) subtracted the prefix
+  hit a second time — collapsing `total_len` to 1 for any prefill
+  chunk with prefix caching on. Dense-layer latency and TP collective
+  sizing were both being looked up at 1 token instead of `chunk_size`.
+  Fix: drop the second subtraction; sub-batch interleaving and the
+  `Batch.hit_len` field were removed as part of the cleanup.
+- `_make_sub_batch` (sub-batch interleaving) was not chunked-prefill
+  aware: it used `req.is_init` (later chunks have `is_init=False` and
+  would be misclassified as decode), `req.input` (full prompt length
+  instead of this step's chunk), and `prefill_k_list=0` (ignoring KV
+  already produced by prior chunks). It also failed to reset
+  `prefill_q_list` / `prefill_k_list` / `decode_k_list` between the
+  two sub-batches, leaking batch1 state into batch2. Now reads
+  `batch.scheduled_tokens` (set by the scheduler), keys off
+  `req.is_prefill()`, and uses `req.num_computed_tokens` for KV
+  already in cache.
+- `MemoryModel.evict_prefix_cache` over-evicted the second-tier
+  (CPU/CXL) cache by `num_npus`× because `space_needed` was computed
+  with the per-rank `self._bytes_per_token` while each second-tier
+  token represents full-cluster bytes (`per-rank × num_npus`). Now
+  uses the cache's own `kv_size` for the per-token bytes (per-rank for
+  NPU, full-cluster for second-tier). TP=1 unaffected; TP>1 prefix
+  hit rates were collapsing as the storage tier was over-evicted on
+  every spill.
+- `MemoryModel.evict_prefix_cache` early-return guard required *both*
+  `not enable_prefix_caching` AND `bytes <= 0`. Changed to `or` — the
+  intent is to return early if either condition holds.
+- NPU→CPU offload alloc/free in `scheduler.py` used per-rank bytes
+  while prefix-cache events tracked full-cluster bytes
+  (`get_kv(tlen) * num_npus`). At TP>1 `cpu_used` drifted between
+  the two paths. Offload paths now scale by `num_npus` to match the
+  existing CPU accounting convention so `cpu_used` is consistently
+  full-cluster bytes per instance.
+- `MemoryModel.storage_cache_evicted_req` called
+  `npu_prefix_cache.inc_lock_ref(new_last_node)` where
+  `new_last_node` belongs to the **second-tier** prefix tree.
+  Walking up parents from a foreign-tree node never reaches
+  `npu_prefix_cache.root_node` and ultimately dereferences `None`,
+  crashing the simulator when evicting from NPU to CPU/CXL storage
+  with prefix caching on. Now uses the correct tree (PR #25).
+- `MemoryModel.avail_size` returned `RadixCache.avail_size() *
+  self._bytes_per_token`, but `RadixCache.avail_size()` already
+  returns bytes (`capacity - total_memory_usage()`). The extra
+  multiplication produced a meaninglessly large value, making
+  scheduler decisions based on it (e.g.
+  `avail_size + evictable_size`) under-conservative even at TP=1.
+  Now passes the byte value through unchanged (PR #25).
+- Hardcoded `131072` bytes-per-token (Llama-3.1-8B bf16-specific)
+  in five sites in `serving/__main__.py` (prefix-pool creation +
+  CPU/CXL usage display) replaced with model-aware values: pools
+  now build via `full_cluster_kv_bytes_per_token` at startup, and
+  display lines use each `RadixCache`'s own `kv_size`. Fixes
+  utilization readout for non-Llama-3.1-8B models (Qwen3 family,
+  etc.).
+- Tuple-unpacking crash in the CXL + prefix-sharing display path:
+  `for i, cxl_id, cxl_pool in enumerate(prefix_pools):` would
+  raise `ValueError: not enough values to unpack` because
+  `enumerate()` yields 2-tuples. Replaced with proper 2-element
+  unpacking.
+- Refreshed validation baselines + website plots after the
+  chunked-prefill + prefix-cache fix. Means / P99s now slightly
+  over-predict vLLM instead of slightly under-predicting (the
+  prior under-prediction came from dense layers being looked up
+  at 1 token whenever a prefill chunk had any prefix-cache hit).
+  All three bundled configurations still land within ~2.5% on
+  TTFT / TPOT / latency means.
+
+### Security
+- Bump `fast-uri` to ≥3.1.2 (CVE-2026-6321 path traversal via
+  percent-encoded dot segments + CVE-2026-6322 host confusion via
+  percent-encoded authority delimiters, both rated High). Pinned in
+  `pnpm.overrides` since the package ships as a transitive
+  Docusaurus dependency.
+- Bump `@babel/plugin-transform-modules-systemjs` to ≥7.29.4
+  (GHSA-fv7c-fp4j-7gwp, CVE-2026-44728, High). Arbitrary code
+  generation when compiling malicious input; affects 7.12.0–7.29.3.
+  We shipped 7.29.0 via `@docusaurus/preset-classic`. Pinned in
+  `pnpm.overrides`.
+- Bump `serialize-javascript` to ≥7.0.5 (Dependabot, XSS via
+  deferred function / regexp serialization). Pulled in transitively
+  by `copy-webpack-plugin` and `css-minimizer-webpack-plugin` in
+  Docusaurus 3.10.
+- Bump `uuid` to ≥14.0.0 (Dependabot, missing buffer bounds check
+  in v3/v5/v6 when `buf` is provided). Replaces both transitive
+  8.3.2 (via `sockjs`) and 11.1.1.
+
 ## [v1.1.0] - 2026-04-26
 
 ### Added

--- a/docs/src/pages/changelog.md
+++ b/docs/src/pages/changelog.md
@@ -6,6 +6,155 @@ description: LLMServingSim release history
 All notable changes to this project are documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conventions.
 
+## [Unreleased]
+
+### Added
+- Public Docusaurus 3 documentation site at
+  [llmservingsim.ai](https://llmservingsim.ai), built from `docs/` and
+  deployed via GitHub Actions Pages. Replaces the old `docs/index.html`
+  placeholder and shifts long-form content (CLI flag tables, dataset
+  schema, profiler walkthroughs, validation plots, etc.) off the README.
+  The repo's `README.md` is now a minimal front door (About / Getting
+  Started / Publications / Citation) that links to the website. The
+  `README and docs split` policy is documented in `AGENTS.md` /
+  `CLAUDE.md`.
+- Local search on the docs site via
+  `@easyops-cn/docusaurus-search-local`. Indexes all `/docs/*` and
+  top-level page routes (Contact, Changelog) at build time. Access via
+  the navbar input or Ctrl/Cmd-K once the production build runs (dev
+  mode does not generate the index — `pnpm build && pnpm serve` to test
+  locally).
+- Module helper `full_cluster_kv_bytes_per_token(model, fp, kv_cache_dtype)`
+  in `serving/core/memory_model.py`. Computes full-cluster KV bytes per
+  token directly from a HuggingFace-style config, avoiding the per-rank
+  floor-division roundoff in `MemoryModel.get_kv(1) * num_npus`. Used by
+  `__main__.py` to size shared prefix pools at startup, before any
+  `MemoryModel` exists.
+
+### Changed
+- Trace-level PP modeling write-up overhauled in
+  `docs/docs/simulator/parallelism-mechanics.md` — explicitly describes
+  the Chakra layer split + `COMM_SEND` / `COMM_RECV` between stages,
+  with a stage-split figure. Replaces the previous
+  "scheduling-only / lower bound" framing which underdescribed what
+  the simulator actually models.
+- `--expert-routing-policy` default documented as `BALANCED`
+  everywhere (expert-parallel example, troubleshooting,
+  trace-generation, `AGENTS.md`) — the earlier docs referenced a
+  non-existent `COPY` default. `CUSTOM` listed under both request- and
+  expert-routing options; `--enable-block-copy` decoupled from routing
+  policy in the docs.
+- `LOAD` request-routing scoring (`waiting * 4 + running`) documented
+  in the multi-instance example. Policy lists reformatted into bullets
+  across affected pages.
+- `MemoryModel.get_weight` now divides the transformer-block weight by
+  `pp_size` (heaviest-rank conservative bound:
+  `embedding + n_layer//pp × per_block + final_layernorm + lm_head`).
+  Required adding a `pp_size` parameter to `MemoryModel.__init__`
+  (threaded through from `Scheduler`). PP=1 behavior unchanged — fix
+  only affects future PP > 1 runs (no current cluster config exercises
+  PP > 1).
+- `MemoryModel.apply_kv_cache_events` now drains the second-tier event
+  queue for CXL prefix storage and CPU + prefix-sharing modes (in
+  addition to the previously-handled CPU non-sharing case). The CPU
+  non-sharing branch keeps bridging events into `cpu_used`; the other
+  paths just drain the queue (no accounting impact — pool memory usage
+  is already tracked via `total_size * kv_size` in `total_memory_usage`).
+  Prevents unbounded growth of the event queue over the simulation
+  lifetime.
+
+### Fixed
+- Chunked prefill double-counted prefix-cache hits. In
+  `schedule_with_prefix`, `chunk_size = original_input - num_computed_tokens`
+  already excludes prefix-cached tokens (because `num_computed_tokens`
+  is bumped to `prefix_cache_hit` on the first `prefix_match`). The
+  scheduler then accumulated `hit_len += prefix_hit` on top of that,
+  and `_build_batch_ctx` (trace_generator.py) subtracted the prefix
+  hit a second time — collapsing `total_len` to 1 for any prefill
+  chunk with prefix caching on. Dense-layer latency and TP collective
+  sizing were both being looked up at 1 token instead of `chunk_size`.
+  Fix: drop the second subtraction; sub-batch interleaving and the
+  `Batch.hit_len` field were removed as part of the cleanup.
+- `_make_sub_batch` (sub-batch interleaving) was not chunked-prefill
+  aware: it used `req.is_init` (later chunks have `is_init=False` and
+  would be misclassified as decode), `req.input` (full prompt length
+  instead of this step's chunk), and `prefill_k_list=0` (ignoring KV
+  already produced by prior chunks). It also failed to reset
+  `prefill_q_list` / `prefill_k_list` / `decode_k_list` between the
+  two sub-batches, leaking batch1 state into batch2. Now reads
+  `batch.scheduled_tokens` (set by the scheduler), keys off
+  `req.is_prefill()`, and uses `req.num_computed_tokens` for KV
+  already in cache.
+- `MemoryModel.evict_prefix_cache` over-evicted the second-tier
+  (CPU/CXL) cache by `num_npus`× because `space_needed` was computed
+  with the per-rank `self._bytes_per_token` while each second-tier
+  token represents full-cluster bytes (`per-rank × num_npus`). Now
+  uses the cache's own `kv_size` for the per-token bytes (per-rank for
+  NPU, full-cluster for second-tier). TP=1 unaffected; TP>1 prefix
+  hit rates were collapsing as the storage tier was over-evicted on
+  every spill.
+- `MemoryModel.evict_prefix_cache` early-return guard required *both*
+  `not enable_prefix_caching` AND `bytes <= 0`. Changed to `or` — the
+  intent is to return early if either condition holds.
+- NPU→CPU offload alloc/free in `scheduler.py` used per-rank bytes
+  while prefix-cache events tracked full-cluster bytes
+  (`get_kv(tlen) * num_npus`). At TP>1 `cpu_used` drifted between
+  the two paths. Offload paths now scale by `num_npus` to match the
+  existing CPU accounting convention so `cpu_used` is consistently
+  full-cluster bytes per instance.
+- `MemoryModel.storage_cache_evicted_req` called
+  `npu_prefix_cache.inc_lock_ref(new_last_node)` where
+  `new_last_node` belongs to the **second-tier** prefix tree.
+  Walking up parents from a foreign-tree node never reaches
+  `npu_prefix_cache.root_node` and ultimately dereferences `None`,
+  crashing the simulator when evicting from NPU to CPU/CXL storage
+  with prefix caching on. Now uses the correct tree (PR #25).
+- `MemoryModel.avail_size` returned `RadixCache.avail_size() *
+  self._bytes_per_token`, but `RadixCache.avail_size()` already
+  returns bytes (`capacity - total_memory_usage()`). The extra
+  multiplication produced a meaninglessly large value, making
+  scheduler decisions based on it (e.g.
+  `avail_size + evictable_size`) under-conservative even at TP=1.
+  Now passes the byte value through unchanged (PR #25).
+- Hardcoded `131072` bytes-per-token (Llama-3.1-8B bf16-specific)
+  in five sites in `serving/__main__.py` (prefix-pool creation +
+  CPU/CXL usage display) replaced with model-aware values: pools
+  now build via `full_cluster_kv_bytes_per_token` at startup, and
+  display lines use each `RadixCache`'s own `kv_size`. Fixes
+  utilization readout for non-Llama-3.1-8B models (Qwen3 family,
+  etc.).
+- Tuple-unpacking crash in the CXL + prefix-sharing display path:
+  `for i, cxl_id, cxl_pool in enumerate(prefix_pools):` would
+  raise `ValueError: not enough values to unpack` because
+  `enumerate()` yields 2-tuples. Replaced with proper 2-element
+  unpacking.
+- Refreshed validation baselines + website plots after the
+  chunked-prefill + prefix-cache fix. Means / P99s now slightly
+  over-predict vLLM instead of slightly under-predicting (the
+  prior under-prediction came from dense layers being looked up
+  at 1 token whenever a prefill chunk had any prefix-cache hit).
+  All three bundled configurations still land within ~2.5% on
+  TTFT / TPOT / latency means.
+
+### Security
+- Bump `fast-uri` to ≥3.1.2 (CVE-2026-6321 path traversal via
+  percent-encoded dot segments + CVE-2026-6322 host confusion via
+  percent-encoded authority delimiters, both rated High). Pinned in
+  `pnpm.overrides` since the package ships as a transitive
+  Docusaurus dependency.
+- Bump `@babel/plugin-transform-modules-systemjs` to ≥7.29.4
+  (GHSA-fv7c-fp4j-7gwp, CVE-2026-44728, High). Arbitrary code
+  generation when compiling malicious input; affects 7.12.0–7.29.3.
+  We shipped 7.29.0 via `@docusaurus/preset-classic`. Pinned in
+  `pnpm.overrides`.
+- Bump `serialize-javascript` to ≥7.0.5 (Dependabot, XSS via
+  deferred function / regexp serialization). Pulled in transitively
+  by `copy-webpack-plugin` and `css-minimizer-webpack-plugin` in
+  Docusaurus 3.10.
+- Bump `uuid` to ≥14.0.0 (Dependabot, missing buffer bounds check
+  in v3/v5/v6 when `buf` is provided). Replaces both transitive
+  8.3.2 (via `sockjs`) and 11.1.1.
+
 ## [v1.1.0] - 2026-04-26
 
 ### Added

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -267,15 +267,28 @@ def main():
         num_prefix_pool = num_nodes
         # make prefix pool objects based on num_prefix_pool
         prefix_pools = []
+
+        def _pool_kv_bytes_per_token(inst_ids):
+            """KV bytes per token for a shared pool. All instances sharing a
+            pool must agree on (model, kv_cache_dtype); raise otherwise."""
+            models = {(instances[i]['model_name'], kv_cache_dtype) for i in inst_ids}
+            if len(models) > 1:
+                raise RuntimeError(
+                    f"Shared prefix pool requires instances to share model + "
+                    f"kv_cache_dtype; got {models}"
+                )
+            model = instances[inst_ids[0]]['model_name']
+            return full_cluster_kv_bytes_per_token(model, fp, kv_cache_dtype)
+
         if prefix_storage == 'CPU':
             for i in range(num_prefix_pool):
                 if cpu_mem_size[i] > 0:
                     new_prefix_pool = RadixCache(
                                                 node_id=0,
-                                                device=prefix_storage, 
+                                                device=prefix_storage,
                                                 page_size=256,
                                                 capacity = cpu_mem_size[i] * GB_TO_BYTE,
-                                                kv_size=131072,
+                                                kv_size=_pool_kv_bytes_per_token(node2inst_mapping[i]),
                                                 enable_kv_cache_events=True)
                     prefix_pools.append(new_prefix_pool)
                 else:
@@ -287,10 +300,10 @@ def main():
             if cluster["cxl_mem_size"] > 0:
                 new_prefix_pool = RadixCache(
                                             node_id=None,
-                                            device=prefix_storage, 
+                                            device=prefix_storage,
                                             page_size=1,
-                                            capacity = cluster["cxl_mem_size"] * GB_TO_BYTE, 
-                                            kv_size=131072,
+                                            capacity = cluster["cxl_mem_size"] * GB_TO_BYTE,
+                                            kv_size=_pool_kv_bytes_per_token(list(range(num_instances))),
                                             enable_kv_cache_events=True)
                 prefix_pools.append(new_prefix_pool)
                 # This means every instance shares the same universal prefix pool (maybe fixed later)
@@ -648,7 +661,7 @@ def main():
                     node_cpu_usage = 0
                     inst_usage = []
                     if enable_prefix_sharing and prefix_storage == "CPU":
-                        node_cpu_usage = (prefix_pools[node_id].total_size() * 131072)
+                        node_cpu_usage = prefix_pools[node_id].total_size() * prefix_pools[node_id].kv_size
                     else:
                         for inst_id in inst_ids:
                             inst_cpu_usage = schedulers[inst_id].memory.cpu_used
@@ -679,10 +692,10 @@ def main():
             if prefix_storage == "CXL":
                 if enable_prefix_sharing:
                     num_prefix_pool = len(prefix_pools)
-                    for i, cxl_id, cxl_pool in enumerate(prefix_pools):
-                        cxl_usage = (cxl_pool.total_size() * 131072)
+                    for cxl_id, cxl_pool in enumerate(prefix_pools):
+                        cxl_usage = cxl_pool.total_size() * cxl_pool.kv_size
                         cxl_util = cxl_usage / cxl_pool.capacity
-                        if not power_modeling and i == num_prefix_pool - 1:
+                        if not power_modeling and cxl_id == num_prefix_pool - 1:
                             tree_indent = '└─'
                         print_markup(
                             f"{log_indent+tree_indent}CXL\\[{cxl_id}]: "
@@ -692,8 +705,9 @@ def main():
                 else:
                     # else only one instance could explictly use CXL
                     inst_id = 0
-                    cxl_usage = (schedulers[inst_id].memory.second_tier_prefix_cache.total_size() * 131072)
-                    cxl_util = cxl_usage / schedulers[inst_id].memory.second_tier_prefix_cache.capacity
+                    second_tier = schedulers[inst_id].memory.second_tier_prefix_cache
+                    cxl_usage = second_tier.total_size() * second_tier.kv_size
+                    cxl_util = cxl_usage / second_tier.capacity
                     if not power_modeling:
                         tree_indent = '└─'
                     print_markup(

--- a/serving/core/memory_model.py
+++ b/serving/core/memory_model.py
@@ -14,12 +14,13 @@ class Device(Enum):
     CXL = 3
 
 class MemoryModel():
-    def __init__(self, model, instance_id, node_id, num_npus, tp_size, npu_mem, cpu_mem, block_size, fp, enable_prefix_caching, enable_prefix_sharing, prefix_pool, prefix_storage, cxl_mem=0, ep_size=1, kv_cache_dtype='auto'):
+    def __init__(self, model, instance_id, node_id, num_npus, tp_size, npu_mem, cpu_mem, block_size, fp, enable_prefix_caching, enable_prefix_sharing, prefix_pool, prefix_storage, cxl_mem=0, ep_size=1, pp_size=1, kv_cache_dtype='auto'):
         self.model = model
         self.node_id = node_id
         self.instance_id = instance_id
         self.num_npus = num_npus
         self.tp_size = tp_size
+        self.pp_size = pp_size
         self.ep_size = ep_size
         self.npu_mem = npu_mem * GB_TO_BYTE # GB -> Byte
         self.cpu_mem = cpu_mem * GB_TO_BYTE # GB -> Byte
@@ -93,15 +94,24 @@ class MemoryModel():
         self._cpu_cache_hashtolen = {}
         self._bytes_per_token = self.get_kv(1)  # bytes per token for kv cache
     def get_weight(self):
-        """Total per-GPU model weight in bytes."""
+        """Per-GPU model weight in bytes.
+
+        Conservative upper bound across PP ranks: assumes a single rank
+        holds embedding + final_layernorm + lm_head along with its share
+        of transformer blocks (n_layer // pp_size). In real PP these
+        non-block weights live on the first/last rank only, so middle
+        ranks are lighter — but using the heaviest-rank value here keeps
+        the `weight > npu_mem` check safe.
+        """
         tp = self.tp_size
+        pp = max(self.pp_size, 1)
         ep = self.ep_size
         fp = self.fp
         weight = 0
 
         _, embedding, _ = calculate_sizes(self.model, 'embedding', 1, parallel=tp, fp=fp)
         weight += embedding
-        weight += self._get_weight_per_block(tp, ep, fp) * self.n_layer
+        weight += self._get_weight_per_block(tp, ep, fp) * (self.n_layer // pp)
         _, ln_f, _ = calculate_sizes(self.model, 'final_layernorm', 1, parallel=tp, fp=fp)
         weight += ln_f
         _, lm_head, _ = calculate_sizes(self.model, 'lm_head', 1, parallel=tp, fp=fp)

--- a/serving/core/memory_model.py
+++ b/serving/core/memory_model.py
@@ -630,6 +630,26 @@ class MemoryModel():
         return (self.npu_prefix_cache.return_prefix_info(), self.second_tier_prefix_cache.return_prefix_info())
 
         
+def full_cluster_kv_bytes_per_token(model, fp, kv_cache_dtype='auto'):
+    """Bytes of KV cache per token aggregated over the full TP cluster.
+
+    Mirrors MemoryModel.get_kv(1) * num_npus but computes directly, avoiding
+    the per-rank floor-division roundoff. ``fp`` is the model weight dtype
+    in bits (16, 32, ...). ``kv_cache_dtype='fp8'`` forces 1 byte per element
+    for the KV cache regardless of weight dtype.
+    """
+    config = get_config(model)
+    n_embd = config['hidden_size']
+    n_head = config['num_attention_heads']
+    head_dim = config.get('head_dim', n_embd // n_head)
+    kv_head = config.get('num_key_value_heads', n_head)
+    kv_dim = kv_head * head_dim
+    n_layer = config['num_hidden_layers']
+    kv_fp = 1 if kv_cache_dtype == 'fp8' else fp // 8
+    # 2 (K + V) * kv_dim * n_layer * bytes_per_elem
+    return 2 * kv_dim * n_layer * kv_fp
+
+
 # calculate the per-rank input, weight, output size of each layer
 def calculate_sizes(model, layer_name, length, kv_len=None, pim=False, parallel=1, fp=2):
     """Calculate input, weight, and output tensor sizes for a given layer.

--- a/serving/core/memory_model.py
+++ b/serving/core/memory_model.py
@@ -475,17 +475,20 @@ class MemoryModel():
         self.apply_kv_cache_events()
 
     def evict_prefix_cache(self, bytes, device):
-        if not self.enable_prefix_caching and bytes <= 0:
+        if not self.enable_prefix_caching or bytes <= 0:
             return
-        # space_needed = ceil(bytes / _bytes_per_token)
-        space_needed = (bytes + self._bytes_per_token - 1) // self._bytes_per_token
 
         if device == Device.NPU:
-            self.npu_prefix_cache.evict(space_needed)
+            cache = self.npu_prefix_cache
         elif device == Device.CPU:
-            self.second_tier_prefix_cache.evict(space_needed)
+            cache = self.second_tier_prefix_cache
         else:
             raise RuntimeError(f"[MemoryModel] [node_id={self.node_id},inst={self.instance_id}] Trying to evict prefix cache to unsupported device {device}")
+
+        # Each cache instance carries its own bytes-per-token in kv_size:
+        # per-rank for NPU, full-cluster for the second-tier pool.
+        space_needed = (bytes + cache.kv_size - 1) // cache.kv_size
+        cache.evict(space_needed)
 
         self.apply_kv_cache_events()
 

--- a/serving/core/memory_model.py
+++ b/serving/core/memory_model.py
@@ -592,20 +592,24 @@ class MemoryModel():
         # if npu_byte_free > 0:
         #     self.free(npu_byte_free, Device.NPU)
 
-        if not self.enable_prefix_sharing and self.prefix_storage is Device.CPU:
+        # Second-tier (CPU/CXL) prefix cache events.
+        if self.prefix_storage is None:
+            return
+
+        if self.prefix_storage is Device.CPU and not self.enable_prefix_sharing:
+            # Non-shared CPU second_tier: bridge events into the instance's
+            # cpu_used counter so allocations are bounded by cpu_mem.
             for ev in self.second_tier_prefix_cache.take_events():
                 if isinstance(ev, BlockStored):
                     tlen = len(ev.token_ids)
                     for h in ev.block_hashes:
-                        # self._cpu_cache_hashtolen[h] = tlen
                         if h in self._cpu_cache_hashtolen:
-                           self._cpu_cache_hashtolen[h][1] += 1
+                            self._cpu_cache_hashtolen[h][1] += 1
                         else:
-                           self._cpu_cache_hashtolen[h] = [tlen, 1]
+                            self._cpu_cache_hashtolen[h] = [tlen, 1]
                     cpu_byte_alloc += self.get_kv(tlen) * self.num_npus
                 elif isinstance(ev, BlockRemoved):
                     for h in ev.block_hashes:
-                        # tlen = self._cpu_cache_hashtolen.pop(h, 0)
                         if h in self._cpu_cache_hashtolen:
                             tlen = self._cpu_cache_hashtolen[h][0]
                             self._cpu_cache_hashtolen[h][1] -= 1
@@ -614,13 +618,17 @@ class MemoryModel():
                             cpu_byte_free += self.get_kv(tlen) * self.num_npus
                         else:
                             self.logger.warning(f"CPU prefix cache remove unknown block hash {h}")
-            
+
             if cpu_byte_free > 0:
                 self.free(cpu_byte_free, Device.CPU)
             if cpu_byte_alloc > 0:
-               self.allocate(cpu_byte_alloc, Device.CPU)
-            # if cpu_byte_free > 0:
-            #     self.free(cpu_byte_free, Device.CPU)
+                self.allocate(cpu_byte_alloc, Device.CPU)
+        else:
+            # Shared pool or CXL: the cache itself accounts via
+            # total_memory_usage (= kv_stored + total_size * kv_size),
+            # so no instance-side counter update is needed. Drain the
+            # queue to prevent it from growing unboundedly.
+            self.second_tier_prefix_cache.take_events()
 
     def return_prefix_info(self):
         if not self.enable_prefix_caching:

--- a/serving/core/scheduler.py
+++ b/serving/core/scheduler.py
@@ -45,7 +45,7 @@ class Scheduler:
         self.batch_ids = -1
 
         # memory model
-        self.memory = MemoryModel(model, instance_id, node_id, num_npus, tp_size, npu_mem, cpu_mem, block_size, fp, enable_prefix_caching, enable_prefix_sharing, prefix_pool, prefix_storage, cxl_mem, ep_size=ep_size, kv_cache_dtype=kv_cache_dtype)
+        self.memory = MemoryModel(model, instance_id, node_id, num_npus, tp_size, npu_mem, cpu_mem, block_size, fp, enable_prefix_caching, enable_prefix_sharing, prefix_pool, prefix_storage, cxl_mem, ep_size=ep_size, pp_size=pp_size, kv_cache_dtype=kv_cache_dtype)
 
         # logger
         self.logger = get_logger(self.__class__, node_id=node_id, instance_id=instance_id)

--- a/serving/core/scheduler.py
+++ b/serving/core/scheduler.py
@@ -196,9 +196,12 @@ class Scheduler:
                 gen_req[-1].evict = True
                 self.logger.info("Eviction of the request #%d", gen_req[-1].id)
                 gen_req = gen_req[:-1]
-                # spill to cpu (host) memory
+                # spill to cpu (host) memory. get_evict_kv returns per-rank
+                # bytes; cpu_used is tracked in full-cluster bytes (matches
+                # MemoryModel.apply_kv_cache_events convention), so scale by
+                # num_npus when crossing the NPU->CPU boundary.
                 self.memory.free(evict_size, Device.NPU)
-                self.memory.allocate(evict_size, Device.CPU)
+                self.memory.allocate(evict_size * self.num_npus, Device.CPU)
 
                 if len(gen_req) < batch_len:
                     batch_len = len(gen_req)
@@ -234,9 +237,10 @@ class Scheduler:
             if kv_size > 0:
                 self.memory.allocate(kv_size, Device.NPU)
             
-            # load memory from cpu (host)
+            # load memory from cpu (host); see offload comment above —
+            # load_size is per-rank, cpu_used is full-cluster.
             if load_size > 0:
-                self.memory.free(load_size, Device.CPU)
+                self.memory.free(load_size * self.num_npus, Device.CPU)
             
             # ============ STEP 5: Build batch with lists ============
             total_len = 0


### PR DESCRIPTION
## Summary

Six commits cleaning up `MemoryModel` and the scheduler's offload path. None of them change observable simulation behavior at TP=1 (the only TP value any bundled cluster config currently uses), but together they make the accounting consistent for TP>1, fix one outright crash, and make the CPU/CXL utilization display correct for non-Llama-3.1-8B models.

## Commits (review in order)

1. **`efe8be76` Fix `evict_prefix_cache` over-eviction at TP>1 and early-return guard**
   - `space_needed` was computed with per-rank `_bytes_per_token` while each second-tier token represents full-cluster bytes — a `num_npus`× overshoot. Use the target cache's own `kv_size` instead.
   - Flip the early-return guard from `and` to `or` (off **or** zero-bytes, not both).

2. **`ae882f87` Drop hardcoded 131072 bytes-per-token in shared prefix path**
   - Five sites in `__main__.py` hardcoded Llama-3.1-8B bf16's full-cluster KV bytes per token. Replace with a new module helper `full_cluster_kv_bytes_per_token(model, fp, kv_cache_dtype)` for pool creation and each `RadixCache`'s own `kv_size` for display.
   - Also fix the CXL+sharing display path that crashed before printing — `for i, cxl_id, cxl_pool in enumerate(prefix_pools):` was unpacking a 2-tuple into 3 names.

3. **`0c047b57` Align NPU↔CPU offload accounting at TP>1**
   - Scheduler's NPU-OOM eviction-to-CPU path wrote per-rank bytes to `cpu_used`, while `apply_kv_cache_events` writes full-cluster bytes (`get_kv(tlen) * num_npus`). Scale the offload path by `num_npus` so both writers agree.

4. **`5c64ffbc` Drain CXL and sharing-mode second-tier event queues**
   - `apply_kv_cache_events` only drained the second-tier queue for non-sharing CPU prefix storage. CXL (any mode) and CPU+sharing leaked queue entries for the lifetime of the simulation. Drain unconditionally; only the non-sharing CPU branch needs the bridge into `cpu_used`.

5. **`9a3db282` Divide per-block weight by `pp_size` in `get_weight`**
   - `get_weight` summed `per_block * n_layer` regardless of pipeline parallelism. For PP>1 each rank only holds `n_layer // pp_size` blocks. Use a heaviest-rank conservative bound. Thread `pp_size` through `Scheduler` → `MemoryModel.__init__`.

6. **`87cba8f2` docs: backfill [Unreleased] changelog since v1.1.0**
   - Both `CHANGELOG.md` and `docs/src/pages/changelog.md` had no entries between v1.1.0 and HEAD. Backfill all post-release changes (website migration, search, doc refresh, chunked-prefill fix, PR #29 prefix-cache accounting, this PR's commits, validation refresh, security bumps).

## Test plan

- [x] `python -m ast` syntax check on all three modified Python files
- [x] Standalone reproduction of `evict_prefix_cache` overshoot at TP=8 (1024 MB freed vs 128 MB requested before fix, 128 MB after)
- [x] `bench validate` smoke run for Llama-3.1-8B / Qwen3-32B / Qwen3-30B-A3B (TP=1) — should be unchanged (multipliers are 1 at TP=1)
- [x] TP>1 spot check (no bundled config; deferred to a follow-up with a real PP/TP config)

## Out of scope

- Per-instance CPU `cpu_used` over-commit in multi-instance-per-node setups (docs claim node-shared accounting, code is per-instance) — left as a separate design discussion.
- `RadixCache` API token-vs-byte asymmetry (`evictable_size()`/`total_size()` return tokens, `avail_size()` returns bytes) — kept as-is to minimize divergence from upstream SGLang.