### PR TITLE
feat: support per-dimension link settings and sync collective dims

### DIFF
--- a/configs/cluster/README.md
+++ b/configs/cluster/README.md
@@ -44,8 +44,8 @@ Pass a config file to `python -m serving` via `--cluster-config configs/cluster/
 | Field | Type | Description |
 | --- | --- | --- |
 | `num_nodes` | Integer | Number of nodes in the cluster |
-| `link_bw` | Float | Inter-GPU link bandwidth in GB/s |
-| `link_latency` | Float | Inter-GPU link latency in ns |
+| `link_bw` | Float or Array<Float> | ASTRA-Sim topology link bandwidth in GB/s. A scalar is broadcast to all topology dimensions; an array must match the final `npus_count` rank |
+| `link_latency` | Float or Array<Float> | ASTRA-Sim topology link latency in ns. A scalar is broadcast to all topology dimensions; an array must match the final `npus_count` rank |
 
 ### Per-node fields
 
@@ -111,3 +111,4 @@ weights are sharded by `ep_size` (each instance holds `num_local_experts // ep_s
 | `single_node_pim_instance.json` | Single node with PIM-enabled memory + power model |
 | `single_node_power_instance.json` | Single node with power modeling enabled |
 | `dual_node_multi_instance.json` | Two nodes, two instances each |
+| `dual_node_moe_dp_ep_intra_inter_instance.json` | Two-node MoE DP+EP example with per-dimension intra/inter link settings |

--- a/configs/cluster/dual_node_moe_dp_ep_intra_inter_instance.json
+++ b/configs/cluster/dual_node_moe_dp_ep_intra_inter_instance.json
@@ -1,0 +1,55 @@
+{
+    "num_nodes": 2,
+    "link_bw": [128, 16],
+    "link_latency": [500, 20000],
+    "nodes": [
+        {
+            "num_instances": 1,
+            "cpu_mem": {
+                "mem_size": 512,
+                "mem_bw": 256,
+                "mem_latency": 0
+            },
+            "instances": [
+                {
+                    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "num_npus": 2,
+                    "tp_size": 2,
+                    "ep_size": 4,
+                    "dp_group": "A",
+                    "pd_type": null
+                }
+            ]
+        },
+        {
+            "num_instances": 1,
+            "cpu_mem": {
+                "mem_size": 512,
+                "mem_bw": 256,
+                "mem_latency": 0
+            },
+            "instances": [
+                {
+                    "model_name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "num_npus": 2,
+                    "tp_size": 2,
+                    "ep_size": 4,
+                    "dp_group": "A",
+                    "pd_type": null
+                }
+            ]
+        }
+    ]
+}

--- a/docs/docs/examples/cluster-config-explained.mdx
+++ b/docs/docs/examples/cluster-config-explained.mdx
@@ -69,13 +69,15 @@ The file has three nested levels. We'll walk through them top-down.
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `num_nodes` | int | Number of physical nodes in the cluster |
-| `link_bw` | float | Inter-node link bandwidth in **GB/s** |
-| `link_latency` | float | Inter-node link latency in **ns** |
+| `link_bw` | float or float[] | ASTRA-Sim topology link bandwidth in **GB/s** |
+| `link_latency` | float or float[] | ASTRA-Sim topology link latency in **ns** |
 | `nodes` | array | One entry per node (length must match `num_nodes`) |
 
 For multi-node setups (e.g., two boxes in a rack), set `num_nodes: 2`
-and add a second node entry. Inter-node communication uses
-`link_bw` / `link_latency`.
+and add a second node entry. `link_bw` / `link_latency` can be either:
+
+- a scalar, broadcast to every ASTRA-Sim topology dimension
+- an array, with one value per final `network.yml::npus_count` dimension
 
 **Optional top-level fields:**
 
@@ -218,6 +220,7 @@ example in this section uses one of them:
 | `single_node_pim_instance.json` | [PIM attention offload](./disaggregated/pim-attention-offload) |
 | `single_node_power_instance.json` | [Power modeling](./advanced/power-modeling) |
 | `dual_node_multi_instance.json` | Multi-node setups |
+| `dual_node_moe_dp_ep_intra_inter_instance.json` | Two-node DP+EP MoE with per-dimension intra/inter `link_bw` / `link_latency` |
 | ... | ... |
 
 ## What's next

--- a/docs/docs/reference/cluster-config.md
+++ b/docs/docs/reference/cluster-config.md
@@ -33,10 +33,14 @@ generates derived ASTRA-Sim input files (`network.yml`,
 | Field | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
 | `num_nodes` | int | ✓ |  | Number of physical nodes in the cluster |
-| `link_bw` | float | ✓ |  | Inter-node link bandwidth in **GB/s** |
-| `link_latency` | float | ✓ |  | Inter-node link latency in **ns** |
+| `link_bw` | float or float[] | ✓ |  | ASTRA-Sim topology link bandwidth in **GB/s**. Scalars apply to every topology dimension; arrays must match the final `network.yml::npus_count` rank |
+| `link_latency` | float or float[] | ✓ |  | ASTRA-Sim topology link latency in **ns**. Scalars apply to every topology dimension; arrays must match the final `network.yml::npus_count` rank |
 | `nodes` | array | ✓ |  | Length must equal `num_nodes` |
 | `cxl_mem` | object | optional | absent | CXL memory expansion (see below) |
+
+Example: if `network.yml` will end up with `npus_count: [4, 2]`, you may set
+`link_bw: [900, 100]` and `link_latency: [0, 20000]` to assign different
+bandwidth/latency per topology dimension.
 
 ## `cxl_mem` (top-level, optional)
 

--- a/serving/core/config_builder.py
+++ b/serving/core/config_builder.py
@@ -16,6 +16,13 @@ yaml.add_representer(FlowStyleList, represent_flowstyle_list)
 
 logger = get_logger("ConfigBuilder")
 
+_COLLECTIVE_IMPL_KEYS = [
+    "all-reduce-implementation",
+    "all-gather-implementation",
+    "reduce-scatter-implementation",
+    "all-to-all-implementation",
+]
+
 
 def _resolve_parallelism(instance, model_config):
     """Infer and validate tp_size, pp_size, ep_size from partial config.
@@ -145,6 +152,86 @@ def _resolve_dp_groups(all_instances):
             inst["ep_total"] = inst["ep_size"]
             inst["tp_dim"] = None
             inst["ep_dim"] = None
+
+
+def _compute_network_dims(instances):
+    """Infer ASTRA-Sim topology dimensions from resolved instances."""
+    dp_groups = {}
+    for inst in instances:
+        dg = inst.get("dp_group")
+        if dg is not None:
+            dp_groups.setdefault(dg, []).append(inst)
+
+    if dp_groups:
+        # DP group mode: topology = [tp_size, dp_group_size]
+        # All instances in DP group must have same tp_size (validated by
+        # _resolve_dp_groups).
+        first_group = next(iter(dp_groups.values()))
+        dims = [first_group[0]["tp_size"], len(first_group)]
+    else:
+        # Independent instances: standard topology.
+        total_npu = sum(
+            inst["num_npus"] if inst.get("pd_type") != "prefill"
+            else inst["num_npus"] * 2
+            for inst in instances
+        )
+        total_pp = sum(
+            inst["pp_size"] if inst.get("pd_type") != "prefill"
+            else inst["pp_size"] * 2
+            for inst in instances
+        )
+        num_instances = len(instances) + sum(
+            1 for inst in instances if inst.get("pd_type") == "prefill"
+        )
+        if total_npu == total_pp:
+            npus_per_group = total_npu // num_instances
+            dims = [npus_per_group, num_instances]
+        else:
+            npus_per_group = total_npu // total_pp
+            dims = [npus_per_group, total_pp]
+
+    # Remove trailing 1s (single-element dimensions are unnecessary).
+    while len(dims) > 1 and dims[-1] == 1:
+        dims.pop()
+    return dims
+
+
+def _normalize_network_dim_values(raw_value, num_dims, field_name):
+    """Normalize scalar-or-list network settings to one float per topology dim."""
+    if isinstance(raw_value, list):
+        if len(raw_value) != num_dims:
+            raise ValueError(
+                f"'{field_name}' must have exactly {num_dims} value(s) to match "
+                f"the ASTRA-Sim topology dimensions, but got {len(raw_value)}."
+            )
+        values = raw_value
+    elif isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool):
+        values = [raw_value] * num_dims
+    else:
+        raise TypeError(
+            f"'{field_name}' must be a number or a list of numbers, "
+            f"got {type(raw_value).__name__}."
+        )
+
+    try:
+        return FlowStyleList([float(v) for v in values])
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"'{field_name}' must contain only numeric values."
+        ) from exc
+
+
+def _sync_system_collective_dims(system_config_path, instances):
+    """Match system collective implementation arity to final topology dims."""
+    with open(system_config_path) as f:
+        system_config = json.load(f)
+
+    num_dims = len(_compute_network_dims(instances))
+    for key in _COLLECTIVE_IMPL_KEYS:
+        system_config[key] = ["ring"] * num_dims
+
+    with open(system_config_path, "w", encoding="utf-8") as f:
+        json.dump(system_config, f, ensure_ascii=False, indent=2)
 
 
 # parse cluster configuration from JSON file and build config file for astra-sim
@@ -395,14 +482,6 @@ def build_cluster_config(astra_sim, cluster_config_path, enable_local_offloading
                 # sync local-mem-bw in system config with npu_mem bw
                 system_config["local-mem-bw"] = int(npu_mem["mem_bw"])
 
-                # Match collective implementation entries to topology dimensions
-                # (ASTRA-Sim creates one topology per implementation entry)
-                has_dp = any(inst.get("dp_group") for inst in instances)
-                num_dims = 2 if has_dp else 1
-                for key in ["all-reduce-implementation", "all-gather-implementation",
-                            "reduce-scatter-implementation", "all-to-all-implementation"]:
-                    system_config[key] = ["ring"] * num_dims
-
                 with open(system_config_path, "w", encoding="utf-8") as f:
                     json.dump(system_config, f, ensure_ascii=False, indent=2)
                 
@@ -503,22 +582,27 @@ def build_cluster_config(astra_sim, cluster_config_path, enable_local_offloading
             block_mode_on.append(block_mode)
 
         
-        total_npu = sum(inst["num_npus"] if inst["pd_type"] != "prefill" else inst["num_npus"] * 2 for inst in total_instances)
-
-        # Resolve DP groups across all instances
-        _resolve_dp_groups(total_instances)
-
-        # create network config file
-        _create_network_config(network_config_path, total_instances, link_bw, link_latency)
-
-        # generate memory config file
-        with open(memory_config_path, "w", encoding="utf-8") as f:
-            json.dump(memory_config, f, ensure_ascii=False, indent=2)
-
-        # validate memory config file against placement
-        _validate_memory_config(memory_config_path, placement, enable_local_offloading)
-
         node_id += 1
+
+    total_npu = sum(
+        inst["num_npus"] if inst["pd_type"] != "prefill"
+        else inst["num_npus"] * 2
+        for inst in total_instances
+    )
+
+    # Resolve DP groups across all instances.
+    _resolve_dp_groups(total_instances)
+
+    # Keep collective implementation arity aligned with the final global
+    # ASTRA-Sim topology, while preserving the default ring implementation.
+    _sync_system_collective_dims(system_config_path, total_instances)
+
+    # Generate the final ASTRA-Sim input files after all instances are known.
+    _create_network_config(network_config_path, total_instances, link_bw, link_latency)
+    with open(memory_config_path, "w", encoding="utf-8") as f:
+        json.dump(memory_config, f, ensure_ascii=False, indent=2)
+    _validate_memory_config(memory_config_path, placement, enable_local_offloading)
+
     cluster = {
         "num_nodes": num_nodes,
         "num_instances": total_num_instances,
@@ -554,42 +638,13 @@ def _create_network_config(network_config_path, instances, link_bw, link_latency
       - For independent instances: [tp_size, num_groups] — dim 0 for TP, dim 1 for PP/instances
       - Single GPU instances: [1]
     """
-    # Check for DP groups
-    dp_groups = {}
-    for inst in instances:
-        dg = inst.get("dp_group")
-        if dg is not None:
-            dp_groups.setdefault(dg, []).append(inst)
-
-    if dp_groups:
-        # DP group mode: topology = [tp_size, dp_group_size]
-        # All instances in DP group must have same tp_size (validated by _resolve_dp_groups)
-        first_group = next(iter(dp_groups.values()))
-        tp_size = first_group[0]["tp_size"]
-        dp_size = len(first_group)
-        dims = [tp_size, dp_size]
-    else:
-        # Independent instances: standard topology
-        total_npu = sum(inst["num_npus"] if inst.get("pd_type") != "prefill" else inst["num_npus"] * 2 for inst in instances)
-        total_pp = sum(inst["pp_size"] if inst.get("pd_type") != "prefill" else inst["pp_size"] * 2 for inst in instances)
-        num_instances = len(instances) + sum(1 for inst in instances if inst.get("pd_type") == "prefill")
-        if total_npu == total_pp:
-            npus_per_group = total_npu // num_instances
-            dims = [npus_per_group, num_instances]
-        else:
-            npus_per_group = total_npu // total_pp
-            dims = [npus_per_group, total_pp]
-
-    # Remove trailing 1s (single-element dimensions are unnecessary)
-    while len(dims) > 1 and dims[-1] == 1:
-        dims.pop()
-
+    dims = _compute_network_dims(instances)
     num_dims = len(dims)
     topology_data = {
         "topology": FlowStyleList(["FullyConnected"] * num_dims),
         "npus_count": FlowStyleList(dims),
-        "bandwidth": FlowStyleList([float(link_bw)] * num_dims),
-        "latency": FlowStyleList([float(link_latency)] * num_dims),
+        "bandwidth": _normalize_network_dim_values(link_bw, num_dims, "link_bw"),
+        "latency": _normalize_network_dim_values(link_latency, num_dims, "link_latency"),
     }
 
     with open(network_config_path, 'w') as yaml_file:


### PR DESCRIPTION
 related to #32 

## Summary

  - allow `link_bw` and `link_latency` to be specified as either scalars or per-dimension arrays
  - reuse the same inferred topology dimensions for both `network.yml` and `system.json`
  - keep the existing default collective implementation as `ring`
  - add docs and a new cluster-config example for distinct intra-/inter-dimension settings

  ## Motivation

  ASTRA-Sim supports per-dimension bandwidth/latency when `npus_count` is multi-dimensional, but LLMServingSim previously only exposed scalar `link_bw` / `link_latency`.

  While adding array support, I also found that `network.yml` and `system.json` were not using exactly the same topology-dimension inference path. In several multi-
  instance / PD / DP+EP configs, `network.yml` could become 2D while `system.json` still emitted only one collective implementation entry per collective.

  This change centralizes topology-dimension inference so both files stay aligned.

  ## Testing

  ### Syntax / parsing

  ```bash
  python3 -m py_compile serving/core/config_builder.py serving/__main__.py serving/core/trace_generator.py

  python3 - <<'PY'
  import json
  from pathlib import Path
  for path in [
      Path('configs/cluster/dual_node_moe_dp_ep_intra_inter_instance.json'),
      Path('configs/cluster/single_node_single_instance.json'),
  ]:
      with open(path) as f:
          json.load(f)
      print('OK', path.name)
  PY

  Result:

  - passed

  ### Config-builder regression

  python3 - <<'PY'
  import os, sys
  from pathlib import Path
  repo = Path('/app/LLMServingSim')
  os.chdir(repo / 'astra-sim')
  sys.path.insert(0, str(repo))
  from serving.core.config_builder import build_cluster_config
  astra = str(repo / 'astra-sim')
  root = repo / 'configs' / 'cluster'
  errors = []
  for path in sorted(root.glob('*.json')):
      try:
          build_cluster_config(astra, str(path.relative_to(repo)))
          print('OK', path.name)
      except Exception as exc:
          errors.append((path.name, type(exc).__name__, str(exc)))
          print('ERR', path.name, type(exc).__name__, str(exc))
  print('SUMMARY', len(errors), 'errors')
  PY

  Result:

  - 14 / 14 cluster configs generated successfully
  - 0 errors

  ### Topology / collective-dimension consistency

  python3 - <<'PY'
  import json, os, sys, yaml
  from pathlib import Path
  repo = Path('/app/LLMServingSim')
  os.chdir(repo / 'astra-sim')
  sys.path.insert(0, str(repo))
  from serving.core.config_builder import build_cluster_config
  astra = str(repo / 'astra-sim')
  root = repo / 'configs' / 'cluster'
  keys = [
      'all-reduce-implementation',
      'all-gather-implementation',
      'reduce-scatter-implementation',
      'all-to-all-implementation',
  ]
  for path in sorted(root.glob('*.json')):
      build_cluster_config(astra, str(path.relative_to(repo)))
      with open(repo / 'astra-sim/inputs/network/network.yml') as f:
          net = yaml.safe_load(f)
      with open(repo / 'astra-sim/inputs/system/system.json') as f:
          syscfg = json.load(f)
      ndims = len(net['npus_count'])
      lens = {k: len(syscfg[k]) for k in keys}
      assert all(v == ndims for v in lens.values()), (path.name, ndims, lens)
      print('OK', path.name, ndims, lens)
  PY

  Result:

  - 0 mismatches between len(network.yml::npus_count) and all collective implementation arrays in system.json

  ### Smoke run

  mkdir -p /tmp/llmservingsim-bin
  ln -sf "$(command -v python3)" /tmp/llmservingsim-bin/python
  PATH="/tmp/llmservingsim-bin:$PATH" \
  PYTHONPATH="$(pwd)/astra-sim/extern/graph_frontend:$(pwd)/astra-sim/extern/graph_frontend/chakra" \
  python3 -m serving \
    --dtype bfloat16 \
    --cluster-config configs/cluster/single_node_single_instance.json \
    --dataset workloads/example_trace.jsonl \
    --num-reqs 10 \
    --output outputs/pr_smoke_single_10.csv

  Result:

  - exit code 0
  - outputs/pr_smoke_single_10.csv contains 10 data rows
  - workload graphs were regenerated under astra-sim/inputs/workload/...
  - final summary printed successfully
  - observed throughput summary:
      - request throughput: 6.01 req/s
      - average prompt throughput: 72.07 tok/s
      - average generation throughput: 354.94 tok/s

  ## Notes
  - the new example config demonstrates per-dimension intra-/inter-link settings without modifying the existing bundled examples