### PR TITLE
Fix radix tree bug

### DIFF
--- a/serving/core/memory_model.py
+++ b/serving/core/memory_model.py
@@ -412,6 +412,7 @@ class MemoryModel():
             self.npu_prefix_cache.dec_lock_ref(req.npu_last_node)
             # print(f"[UNLOCK] req={req.id} unlock_prefix node_id={node.id} lock_ref_AFTER={node.lock_ref}")
             req.npu_last_node = None
+            req._prefix_locked = False
         elif device == Device.CPU and req.cpu_last_node is not None:
             self.second_tier_prefix_cache.dec_lock_ref(req.cpu_last_node)
             req.cpu_last_node = None
@@ -429,10 +430,12 @@ class MemoryModel():
             
             old_node = req.npu_last_node
             # print(f"[CACHE_UNFINISHED] req={req.id} old_node_id={old_node.id if old_node else None}(lock_ref={old_node.lock_ref if old_node else 'N/A'}) -> new_node_id={new_last_node.id}(lock_ref={new_last_node.lock_ref})")
-            self.npu_prefix_cache.dec_lock_ref(req.npu_last_node)
+            if old_node is not None and req._prefix_locked:
+                self.npu_prefix_cache.dec_lock_ref(old_node)
             self.npu_prefix_cache.inc_lock_ref(new_last_node)
             # print(f"[CACHE_UNFINISHED] req={req.id} AFTER: old_node_id={old_node.id}(lock_ref={old_node.lock_ref}) new_node_id={new_last_node.id}(lock_ref={new_last_node.lock_ref})")
             req.npu_last_node = new_last_node
+            req._prefix_locked = True
             if self.logger.isEnabledFor(logging.DEBUG):
                 # print(f"cache_unfinished_req of req {req.id}")
                 # print(f"===============NPU PREFIX CAHCE of Instance[{self.instance_id}]=================")
@@ -462,7 +465,9 @@ class MemoryModel():
                 # print(f"[CACHE_FINISHED] req={req.id} node_id={node.id if node else None} lock_ref={node.lock_ref if node else 'N/A'} (SKIPPED dec - not locked)")
             else:
                 # print(f"[CACHE_FINISHED] req={req.id} node_id={node.id if node else None} lock_ref_BEFORE={node.lock_ref if node else 'N/A'}")
-                self.npu_prefix_cache.dec_lock_ref(req.npu_last_node)
+                if node is not None:
+                    self.npu_prefix_cache.dec_lock_ref(node)
+                    req.npu_last_node = None
                 req._prefix_locked = False
             # node = req.npu_last_node
             # print(f"[CACHE_FINISHED] req={req.id} node_id={node.id if node else None} lock_ref_BEFORE={node.lock_ref if node else 'N/A'}")

--- a/serving/core/scheduler.py
+++ b/serving/core/scheduler.py
@@ -816,9 +816,18 @@ class Scheduler:
     
     # add decode request to decode instance from prefill instnace
     def add_decode(self, req):
+        req.instance_id = self.instance_id
         self.request.append(req)
-        kv_size = self.memory.get_total_kv(req)
-        self.memory.allocate(kv_size, Device.NPU)
+        if self.enable_prefix_caching:
+            self.memory.prefix_match(req)
+            kv_size = self.memory.get_evict_kv(req)
+            evict_size = max(0, kv_size - self.memory.avail_size(Device.NPU))
+            if evict_size > 0:
+                self.memory.evict_prefix_cache(evict_size, Device.NPU)
+            self.memory.cache_unfinished_req(req, Device.NPU)
+        else:
+            kv_size = self.memory.get_total_kv(req)
+            self.memory.allocate(kv_size, Device.NPU)
     
     # get first request's arrival time
     def get_first_arrival_time(self):


### PR DESCRIPTION
### Bug 1(commit 'fix: Fix prefix cache lock state after PD handoff')
**Description**
when I running `python -m serving   --cluster-config 'configs/cluster/single_node_pd_instance.json'   --dtype bfloat16 --block-size 16   --dataset 'workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl'   --output 'outputs/test.csv'   --log-interval 1.0`, the error is as follows:

_▶ Starting simulation...

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/__main__.py", line 868, in <module>
    main()
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/__main__.py", line 454, in main
    prompt_t, gen_t, finished_reqs = schedulers[instance_id].add_done(id, sys, current)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/core/scheduler.py", line 789, in add_done
    self.memory.cache_unfinished_req(req, Device.NPU)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/core/memory_model.py", line 432, in cache_unfinished_req
    self.npu_prefix_cache.dec_lock_ref(req.npu_last_node)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/core/radix_tree.py", line 402, in dec_lock_ref
    if node.lock_ref == 1:
AttributeError: 'NoneType' object has no attribute 'lock_ref'_

**-Cause:**
    After prefill instance finishes, `unlock_prefix()` clears `npu_last_node` but fields like `_prefix_locked` are not synchronized. Consequently, the decode stage later calls `cache
_unfinished_req()` which unconditionally invokes `dec_lock_ref(req.npu_last_node)`, leading to a `NoneType` object has no attribute 'lock_ref' error.

**-Solution:**
    Ensure `npu_last_node` and `_prefix_locked` always represent the same state. Only release the old node if it actually exists and is held by the current request. After inserting a
nd locking the new node, `_prefix_locked` must be explicitly set to `True`, otherwise it won't be unlocked upon completion, leading to a lock leak.

**-Details**
- `serving/core/memory_model.py:404`: Add `req._prefix_locked = False` immediately after `unlock_prefix()` clears `req.npu_last_node`.
- `serving/core/memory_model.py:423`: Update `cache_unfinished_req()` to release the old lock only when `old_node is not None and req._prefix_locked` evaluates to `True`.
- `serving/core/memory_model.py:425`: Proceed to execute `inc_lock_ref()` on the `new_last_node`.
- `serving/core/memory_model.py:427`: Update `req.npu_last_node = new_last_node`.
- `serving/core/memory_model.py:428`: Add `req._prefix_locked = True`. This line is mandatory to indicate that the new node has been safely locked and is currently held by the request.
- `serving/core/memory_model.py:458`: Ensure `cache_finished_req()` verifies that `node is not None` before releasing the lock for a completed request.
- `serving/core/memory_model.py:460`: Clear `req.npu_last_node = None` after the lock release is completed.
- `serving/core/memory_model.py:461`: Reset `req._prefix_locked = False` upon request completion.


### Bug 2(commit 'fix: fix PD decode KV accounting with prefix cache and incorrect instance_id tracking')
**Description**
After solving bug 1,  a new issue popped up. Also running the same command `python -m serving   --cluster-config 'configs/cluster/single_node_pd_instance.json'   --dtype bfloat16 --block-size 16   --dataset 'workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl'   --output 'outputs/test.csv'   --log-interval 1.0`, the error is as follows:

_[42.0s] Avg prompt throughput: 10643.0 tokens/s, Avg generation throughput: 729.0 tokens/s
         ├─Running Instance[0]: 0 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 25210.51 MB (25.645 % Used), Prefix Cache Hit ratio 79.65 %, (491648 / 617270)
         ├─Running Instance[1]: 13 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 92442.51 MB (94.037 % Used)
         └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
[43.0s] Avg prompt throughput: 21523.0 tokens/s, Avg generation throughput: 743.0 tokens/s
         ├─Running Instance[0]: 1 reqs, Waiting: 1 reqs, Total # 1 NPUs, Each NPU Memory Usage 25284.51 MB (25.721 % Used), Prefix Cache Hit ratio 80.21 %, (512368 / 638793)
         ├─Running Instance[1]: 11 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 95212.51 MB (96.855 % Used)
         └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/__main__.py", line 868, in <module>
    main()
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/__main__.py", line 470, in main
    router.transfer_prefill_request(finished_reqs)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/core/router.py", line 312, in transfer_prefill_request
    self.decode_schedulers[instance_id].add_decode(req)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/core/scheduler.py", line 821, in add_decode
    self.memory.allocate(kv_size, Device.NPU)
  File "/app/LLMServingSim/ttt/LLMServingSim/serving/core/memory_model.py", line 250, in allocate
    raise RuntimeError(
RuntimeError: [MemoryModel] [node_id=0,inst=1] NPU: tried to load 1898.00MB but only 63.49MB is available._

**-Cause:**
    1.The previous `add_decode()` implementation bypassed the radix prefix cache by directly calling `self.memory.allocate(get_total_kv(req), Device.NPU)`. When prefix caching is enabled, this unmanaged allocation increases `npu_used` without associating the KV memory with any radix block. Subsequently, `cache_unfinished_req()` inserts the exact same KV chunk into the radix cache, double-counting the memory and ultimately triggering an Out-Of-Memory (OOM) error for the decode instance.
 2.another little problem: The same Request object is transferred from the prefill scheduler to the decode scheduler, but `req.instance_id` still retains the old prefill instance ID. Although the request eventually finishes on the decode instance, `save_output()` logs the completion using `req.instance_id` when writing to the CSV. This causes decode request metrics to be wrongly attributed to the prefill instance.

**-Solution:**
   1.Shift KV memory management to the decode side's own prefix cache instead of performing a raw, untracked allocation. This ensures the KV data is correctly tracked, evicted, or freed when needed.
    2.Explicitly update the request's running ownership (`req.instance_id`) to the decode instance upon handing off to the decode scheduler. This ensures correct route tracking and precise data logging in the output CSV.

**-Details**
- `serving/core/scheduler.py:821`: Modify `add_decode()` to enter the prefix-cache code path when `enable_prefix_caching` is enabled.
- `serving/core/scheduler.py:822`: Perform `prefix_match(req)` first on the local NPU prefix cache of the decode instance.
- `serving/core/scheduler.py:823`: Calculate the actual KV size that needs to be registered/filled using `get_evict_kv(req)`.
- `serving/core/scheduler.py:824`: Determine the required eviction space based on `avail_size(Device.NPU)`.
- `serving/core/scheduler.py:826`: Trigger `evict_prefix_cache()` if the available memory space is insufficient.
- `serving/core/scheduler.py:827`: Invoke `cache_unfinished_req(req, Device.NPU)` to insert the transferred KV into the radix cache of the decode instance.
- `serving/core/scheduler.py:828`: Retain the legacy `allocate(get_total_kv)` path when prefix caching is disabled.
- `serving/core/scheduler.py:819`: Explicitly set `req.instance_id = self.instance_id` at the beginning of `add_decode()`.


### Test
- Ran syntax checks:
```bash
  python -m py_compile serving/core/memory_model.py serving/core/scheduler.py

- Ran the PD split simulation with prefix caching enabled:
```bash
  python -m serving \
    --cluster-config configs/cluster/single_node_pd_instance.json \
    --dtype bfloat16 \
    --block-size 16 \
    --dataset workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl \
    --output outputs/1node2inspd.csv \
    --log-interval 1.0

  - Verified the run no longer crashes on NoneType.lock_ref during prefix-cache lock updates after P→D handoff.
  - Verified the decode instance no longer OOMs in Scheduler.add_decode() from duplicate KV allocation when prefix caching is enabled.
  - Verified completed PD requests are attributed to the decode instance in the output CSV after handoff.