### PR TITLE
feat: add per-instance runtime config overrides

### DIFF
--- a/configs/cluster/README.md
+++ b/configs/cluster/README.md
@@ -69,6 +69,19 @@ Pass a config file to `python -m serving` via `--cluster-config configs/cluster/
 | `pp_size` | Integer | No | Pipeline parallel degree (default: 1) |
 | `ep_size` | Integer | No | Expert parallel degree (default: `tp_size` for MoE, 1 for dense) |
 | `dp_group` | String/null | No | DP group ID. Instances with the same string share experts via cross-instance ALLTOALL |
+| `max_num_seqs` | Integer | No | Per-instance override for `--max-num-seqs` (`0` = unlimited) |
+| `max_num_batched_tokens` | Integer | No | Per-instance override for `--max-num-batched-tokens` (`0` = unlimited) |
+| `long_prefill_token_threshold` | Integer | No | Per-instance override for `--long-prefill-token-threshold` |
+| `block_size` | Integer | No | Per-instance override for `--block-size` |
+| `dtype` | String | No | Per-instance override for `--dtype` |
+| `kv_cache_dtype` | String | No | Per-instance override for `--kv-cache-dtype` |
+| `enable_chunked_prefill` | Boolean | No | Per-instance override for `--enable-chunked-prefill` |
+| `enable_prefix_caching` | Boolean | No | Per-instance override for `--enable-prefix-caching` |
+| `prioritize_prefill` | Boolean | No | Per-instance override for `--prioritize-prefill` |
+| `enable_local_offloading` | Boolean | No | Per-instance override for `--enable-local-offloading` |
+| `enable_attn_offloading` | Boolean | No | Per-instance override for `--enable-attn-offloading` |
+| `enable_sub_batch_interleaving` | Boolean | No | Per-instance override for `--enable-sub-batch-interleaving` |
+| `enable_block_copy` | Boolean | No | Per-instance override for `--enable-block-copy` |
 
 \* At least one of `num_npus` or `tp_size` must be provided. The other is inferred.
 
@@ -103,6 +116,7 @@ weights are sharded by `ep_size` (each instance holds `num_local_experts // ep_s
 | `single_node_single_instance_H100.json` | Single node on H100 with TP=4 |
 | `single_node_multi_instance.json` | Single node, two instances |
 | `single_node_pd_instance.json` | Single node with prefill/decode disaggregation |
+| `single_node_pd_per_instance_config.json` | P/D disaggregation with prefill/decode-specific runtime limits |
 | `single_node_moe_single_instance.json` | Single node, Qwen3-MoE with TP=2 EP=2 |
 | `single_node_moe_multi_instance.json` | Single node, two MoE instances |
 | `single_node_moe_pd_instance.json` | Single node, MoE with P/D disaggregation |

--- a/configs/cluster/single_node_pd_per_instance_config.json
+++ b/configs/cluster/single_node_pd_per_instance_config.json
@@ -1,0 +1,52 @@
+{
+    "num_nodes": 1,
+    "link_bw": 16,
+    "link_latency": 20000,
+    "nodes": [
+        {
+            "num_instances": 2,
+            "cpu_mem": {
+                "mem_size": 512,
+                "mem_bw": 256,
+                "mem_latency": 0
+            },
+            "instances": [
+                {
+                    "model_name": "meta-llama/Llama-3.1-8B",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "pd_type": "prefill",
+                    "tp_size": 1,
+                    "max_num_seqs": 32,
+                    "max_num_batched_tokens": 8192,
+                    "long_prefill_token_threshold": 2048,
+                    "enable_chunked_prefill": true,
+                    "block_size": 16,
+                    "dtype": "bfloat16",
+                    "kv_cache_dtype": "auto"
+                },
+                {
+                    "model_name": "meta-llama/Llama-3.1-8B",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "pd_type": "decode",
+                    "tp_size": 1,
+                    "max_num_seqs": 256,
+                    "max_num_batched_tokens": 256,
+                    "enable_chunked_prefill": true,
+                    "block_size": 16,
+                    "dtype": "bfloat16",
+                    "kv_cache_dtype": "auto"
+                }
+            ]
+        }
+    ]
+}

--- a/docs/docs/examples/cluster-config-explained.mdx
+++ b/docs/docs/examples/cluster-config-explained.mdx
@@ -206,7 +206,7 @@ the cluster config.
 
 ## Provided configs
 
-The repo ships 13 worked configs under `configs/cluster/`. Each
+The repo ships 15 worked configs under `configs/cluster/`. Each
 example in this section uses one of them:
 
 | Config | Used by |
@@ -214,6 +214,7 @@ example in this section uses one of them:
 | `single_node_single_instance.json` | [Tensor parallel](./parallelism/tensor-parallel) (with `tp_size=2`) |
 | `single_node_multi_instance.json` | [Multi-instance LOAD routing](./disaggregated/multi-instance) |
 | `single_node_pd_instance.json` | [Prefill/decode split](./disaggregated/prefill-decode-split) |
+| `single_node_pd_per_instance_config.json` | P/D split with per-instance runtime limits |
 | `single_node_moe_single_instance.json` | [Expert parallel](./parallelism/expert-parallel) |
 | `single_node_moe_dp_ep_instance.json` | [DP+EP MoE](./parallelism/dp-ep-moe) |
 | `single_node_cxl_instance.json` | [CXL memory tier](./memory-tiers/cxl-memory) |

--- a/docs/docs/reference/cli-flags.md
+++ b/docs/docs/reference/cli-flags.md
@@ -18,6 +18,10 @@ Complete reference for every command-line flag accepted by
 
 ## Batching and scheduling
 
+These flags are deployment defaults. A cluster config can override the
+matching runtime knobs per `instances[i]`; see
+**[Cluster config](./cluster-config#runtime-overrides-optional)**.
+
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--max-num-seqs` | int | `128` | Max sequences in a batch. `0` = unlimited |

--- a/docs/docs/reference/cluster-config.md
+++ b/docs/docs/reference/cluster-config.md
@@ -135,6 +135,8 @@ schema. Top-level structure:
   "ep_size": 1,
   "dp_group": null,
   "pd_type": null,
+  "max_num_seqs": 128,
+  "max_num_batched_tokens": 2048,
   "placement": {...}
 }
 ```
@@ -165,6 +167,28 @@ schema. Top-level structure:
 - `num_npus == tp_size * pp_size` (always)
 - Without `dp_group`: `ep_size <= tp_size`
 - For MoE: `ep_size` must divide `num_local_experts`
+
+### Runtime overrides (optional)
+
+These fields override the matching `python -m serving` CLI flag for this
+instance only. Omitted fields keep the CLI value; for `dtype`, an omitted CLI
+value still falls back to the model config's `torch_dtype`.
+
+| Field | Type | CLI fallback | Description |
+| --- | --- | --- | --- |
+| `max_num_seqs` | int | `--max-num-seqs` | Max active sequences for this instance. `0` means unlimited |
+| `max_num_batched_tokens` | int | `--max-num-batched-tokens` | Per-iteration token budget for this instance. `0` means unlimited |
+| `long_prefill_token_threshold` | int | `--long-prefill-token-threshold` | Per-request chunk cap for chunked prefill |
+| `block_size` | int | `--block-size` | KV-cache block size in tokens |
+| `dtype` | string | `--dtype` | Weight/profile dtype for this instance |
+| `kv_cache_dtype` | string | `--kv-cache-dtype` | KV-cache dtype for memory accounting and profile variant selection |
+| `enable_chunked_prefill` | bool | `--enable-chunked-prefill` | Enable chunked prefill in this instance's scheduler |
+| `enable_prefix_caching` | bool | `--enable-prefix-caching` | Enable this instance's local prefix cache |
+| `prioritize_prefill` | bool | `--prioritize-prefill` | Prefer prefill requests when forming batches |
+| `enable_local_offloading` | bool | `--enable-local-offloading` | Emit graph conversion with local offloading for this instance |
+| `enable_attn_offloading` | bool | `--enable-attn-offloading` | Emit PIM attention offload for this instance |
+| `enable_sub_batch_interleaving` | bool | `--enable-sub-batch-interleaving` | Enable sub-batch interleaving for this instance |
+| `enable_block_copy` | bool | `--enable-block-copy` | Reuse one block trace across repeated transformer blocks |
 
 ### `placement` (optional)
 

--- a/docs/docs/simulator/specialized/pim-offload.md
+++ b/docs/docs/simulator/specialized/pim-offload.md
@@ -164,10 +164,10 @@ to NPU attention for prefill-heavy phases.
 1. **PIM offload is per-node.** `cpu_mem.pim_config` lives on the
    node, not the instance. Multiple instances on the same node share
    the same PIM device.
-2. **`--enable-attn-offloading` is a global flag**, not per-instance.
-   You can't offload attention for some instances but not others in
-   the same simulation. (If you need that, run two simulations and
-   compare.)
+2. **`--enable-attn-offloading` is the CLI default.** Individual
+   instances can override it with `enable_attn_offloading` in the
+   cluster config, but any node that uses PIM offload still needs a
+   `cpu_mem.pim_config`.
 3. **The PIM CSV bundle isn't a thing.** Unlike NPU, PIM attention
    latency is computed analytically from the DRAMSim3 parameters
    plus `pim_model.py`'s arithmetic. Profiling a real PIM device is

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -60,6 +60,80 @@ def _pad_batch_to_max(batch, max_len):
     batch.num_decode += pad              # counted for lm_head / dense shape
 
 
+def _runtime_limit(value):
+    return float('inf') if value == 0 else value
+
+
+def _cluster_config_path(path):
+    if os.path.isabs(path):
+        return path
+    return os.path.join("..", path)
+
+
+def _load_cluster_config_for_overrides(path):
+    with open(_cluster_config_path(path), "r") as f:
+        return json.load(f)
+
+
+def _iter_raw_instances(cluster_config):
+    for node in cluster_config.get("nodes", []):
+        for instance in node.get("instances", []):
+            yield instance
+
+
+def _resolve_instance_dtype(instance, cli_dtype, dtype_to_bits):
+    dtype = instance.get("dtype", cli_dtype)
+    if dtype is None:
+        config = get_config(instance["model_name"])
+        torch_dtype = config.get("torch_dtype")
+        if isinstance(torch_dtype, str) and torch_dtype in dtype_to_bits:
+            dtype = torch_dtype
+        else:
+            dtype = "bfloat16"
+    if dtype not in dtype_to_bits:
+        raise ValueError(f"Unsupported dtype '{dtype}' for instance {instance.get('instance_id')}")
+    return dtype
+
+
+def _build_instance_runtime_configs(instances, args, dtype_to_bits):
+    runtime_configs = []
+    for instance_id, instance in enumerate(instances):
+        dtype = _resolve_instance_dtype(instance, args.dtype, dtype_to_bits)
+        kv_cache_dtype = instance.get("kv_cache_dtype", args.kv_cache_dtype)
+        if kv_cache_dtype not in ("auto", "fp8"):
+            raise ValueError(f"Unsupported kv_cache_dtype '{kv_cache_dtype}' for instance {instance_id}")
+
+        enable_attn_offloading = instance.get("enable_attn_offloading", args.enable_attn_offloading)
+        enable_sub_batch_interleaving = instance.get(
+            "enable_sub_batch_interleaving", args.enable_sub_batch_interleaving)
+        if enable_sub_batch_interleaving and not enable_attn_offloading:
+            raise RuntimeError(
+                f"Instance {instance_id} enables sub-batch interleaving without attention offloading")
+
+        runtime_configs.append({
+            "max_num_seqs": _runtime_limit(instance.get("max_num_seqs", args.max_num_seqs)),
+            "max_num_batched_tokens": _runtime_limit(
+                instance.get("max_num_batched_tokens", args.max_num_batched_tokens)),
+            "long_prefill_token_threshold": instance.get(
+                "long_prefill_token_threshold", args.long_prefill_token_threshold),
+            "block_size": instance.get("block_size", args.block_size),
+            "dtype": dtype,
+            "fp": dtype_to_bits[dtype],
+            "kv_cache_dtype": kv_cache_dtype,
+            "enable_chunked_prefill": instance.get(
+                "enable_chunked_prefill", args.enable_chunked_prefill),
+            "enable_prefix_caching": instance.get(
+                "enable_prefix_caching", args.enable_prefix_caching),
+            "prioritize_prefill": instance.get("prioritize_prefill", args.prioritize_prefill),
+            "enable_local_offloading": instance.get(
+                "enable_local_offloading", args.enable_local_offloading),
+            "enable_attn_offloading": enable_attn_offloading,
+            "enable_sub_batch_interleaving": enable_sub_batch_interleaving,
+            "enable_block_copy": instance.get("enable_block_copy", args.enable_block_copy),
+        })
+    return runtime_configs
+
+
 def main():
     # ----------------------------------------------------------------------------------------------
     # LLMServingSim runs in astra-sim directory for easy path configuration
@@ -161,55 +235,26 @@ def main():
     print_markup("[sim.heading]▶ Starting simulation...[/]\n")
     flush.stdout.flush()
     
-    max_num_seqs=args.max_num_seqs if args.max_num_seqs != 0 else float('inf')
-    max_num_batched_tokens=args.max_num_batched_tokens if args.max_num_batched_tokens != 0 else float('inf')
-    long_prefill_token_threshold=args.long_prefill_token_threshold
-    block_size=args.block_size
-    # Resolve dtype: CLI overrides; otherwise derive from the first instance's
-    # model config torch_dtype (fallback bfloat16). Profile data under the
-    # resulting variant must exist at simulation time.
     _dtype_to_bits = {'float16': 16, 'bfloat16': 16, 'float32': 32, 'fp8': 8, 'int8': 8}
-    dtype = args.dtype
-    if dtype is None:
-        # Peek at cluster config to pick the default model's torch_dtype
-        with open(args.cluster_config, 'r') as _f:
-            _cluster_peek = json.load(_f)
-        _first_model = None
-        for _inst in _cluster_peek.get('instances', []):
-            if _inst.get('model_name'):
-                _first_model = _inst['model_name']
-                break
-        if _first_model is not None:
-            _cfg = get_config(_first_model)
-            _td = _cfg.get('torch_dtype')
-            if isinstance(_td, str) and _td in _dtype_to_bits:
-                dtype = _td
-        if dtype is None:
-            dtype = 'bfloat16'
-        logger.info("--dtype not set; using %s (from model config torch_dtype)", dtype)
-    fp = _dtype_to_bits[dtype]
     request_routing_policy=args.request_routing_policy
     expert_routing_policy=args.expert_routing_policy
-    enable_block_copy=args.enable_block_copy
-    enable_chunked_prefill=args.enable_chunked_prefill
-    enable_prefix_caching=args.enable_prefix_caching
     enable_prefix_sharing=args.enable_prefix_sharing
     prefix_storage=args.prefix_storage
-    enable_local_offloading=args.enable_local_offloading
-    enable_attn_offloading=args.enable_attn_offloading
-    enable_sub_batch_interleaving=args.enable_sub_batch_interleaving
-    if not enable_attn_offloading and enable_sub_batch_interleaving:
-        raise RuntimeError("Sub-batch interleaving requires attention offloading to be enabled")
-    prioritize_prefill=args.prioritize_prefill
     dataset=args.dataset
     output_file=args.output
     is_init = not args.skip_prefill
     num_req=args.num_reqs
     log_interval=args.log_interval
     network_backend = args.network_backend
-    kv_cache_dtype = args.kv_cache_dtype
+    raw_cluster_config = _load_cluster_config_for_overrides(args.cluster_config)
+    raw_instances = list(_iter_raw_instances(raw_cluster_config))
+    build_enable_local_offloading = args.enable_local_offloading or any(
+        inst.get("enable_local_offloading", False) for inst in raw_instances)
+    build_enable_attn_offloading = args.enable_attn_offloading or any(
+        inst.get("enable_attn_offloading", False) for inst in raw_instances)
     # ---------------------------------- Extract cluster config -----------------------------------
-    cluster = build_cluster_config(astra_sim, args.cluster_config, args.enable_local_offloading, args.enable_attn_offloading)
+    cluster = build_cluster_config(
+        astra_sim, args.cluster_config, build_enable_local_offloading, build_enable_attn_offloading)
     num_nodes = cluster["num_nodes"]
     num_instances = cluster["num_instances"]
     instances = cluster["instances"]
@@ -227,6 +272,8 @@ def main():
     power_modeling = cluster["power_modeling"]
     power_configs = cluster["power_configs"]
     pim_models = cluster["pim_models"]
+    instance_runtime_configs = _build_instance_runtime_configs(instances, args, _dtype_to_bits)
+    any_prefix_caching = any(cfg["enable_prefix_caching"] for cfg in instance_runtime_configs)
     # ----------------------------------------- Set config -----------------------------------------
     # Automatic network, memory configuration
     # If you want to set more specific information such as latency, look at config.py and each json file
@@ -263,22 +310,29 @@ def main():
     elif prefix_storage == "CXL":
         pool_device = Device.CXL
 
-    if enable_prefix_caching and enable_prefix_sharing and prefix_storage != 'None':
+    if any_prefix_caching and enable_prefix_sharing and prefix_storage != 'None':
         num_prefix_pool = num_nodes
         # make prefix pool objects based on num_prefix_pool
         prefix_pools = []
 
         def _pool_kv_bytes_per_token(inst_ids):
-            """KV bytes per token for a shared pool. All instances sharing a
-            pool must agree on (model, kv_cache_dtype); raise otherwise."""
-            models = {(instances[i]['model_name'], kv_cache_dtype) for i in inst_ids}
-            if len(models) > 1:
+            """KV bytes per token for a shared pool."""
+            kv_shapes = {
+                (
+                    instances[i]["model_name"],
+                    instance_runtime_configs[i]["fp"],
+                    instance_runtime_configs[i]["kv_cache_dtype"],
+                )
+                for i in inst_ids
+            }
+            if len(kv_shapes) > 1:
                 raise RuntimeError(
-                    f"Shared prefix pool requires instances to share model + "
-                    f"kv_cache_dtype; got {models}"
+                    "Shared prefix pool requires instances to share model, "
+                    f"dtype, and kv_cache_dtype; got {kv_shapes}"
                 )
             model = instances[inst_ids[0]]['model_name']
-            return full_cluster_kv_bytes_per_token(model, fp, kv_cache_dtype)
+            cfg = instance_runtime_configs[inst_ids[0]]
+            return full_cluster_kv_bytes_per_token(model, cfg["fp"], cfg["kv_cache_dtype"])
 
         if prefix_storage == 'CPU':
             for i in range(num_prefix_pool):
@@ -325,16 +379,21 @@ def main():
         
         # Make scheduler for each instance
 
+        inst_cfg = instance_runtime_configs[instance_id]
+
         schedulers.append(Scheduler(
-            instance["model_name"], instance["node_id"], instance_id, max_num_seqs, max_num_batched_tokens,
+            instance["model_name"], instance["node_id"], instance_id,
+            inst_cfg["max_num_seqs"], inst_cfg["max_num_batched_tokens"],
             instance["num_npus"], instance["tp_size"], instance["pp_size"],
             instance["npu_mem"]["mem_size"], cpu_mem_size[instance["node_id"]],
-            inst2npu_mapping[instance_id], instance["pd_type"], fp, block_size, num_req,
-            prioritize_prefill, enable_prefix_caching, enable_prefix_sharing, prefix_pool, pool_device, enable_chunked_prefill,
-            long_prefill_token_threshold,
+            inst2npu_mapping[instance_id], instance["pd_type"],
+            inst_cfg["fp"], inst_cfg["block_size"], num_req,
+            inst_cfg["prioritize_prefill"], inst_cfg["enable_prefix_caching"],
+            enable_prefix_sharing, prefix_pool, pool_device, inst_cfg["enable_chunked_prefill"],
+            inst_cfg["long_prefill_token_threshold"],
             cxl_mem,
             ep_size=instance.get("ep_total", 1),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=inst_cfg["kv_cache_dtype"],
         ))
 
     # Controller for astra-sim process communication
@@ -348,7 +407,7 @@ def main():
         power_model = None
     # Load requests into router (routed in real-time during simulation)
     if dataset != None:
-        router.load_requests(dataset, enable_prefix_caching=enable_prefix_caching, is_init=is_init)
+        router.load_requests(dataset, enable_prefix_caching=any_prefix_caching, is_init=is_init)
     else:
         # Manually adding request (legacy: route all upfront)
         for i in range(16):
@@ -516,16 +575,23 @@ def main():
                     for inst_id in dp_groups[dg]:
                         batch, nid = dp_pending[dg][inst_id]
                         inst = instances[inst_id]
+                        inst_cfg = instance_runtime_configs[inst_id]
                         generate_trace(batch, inst["hardware"], inst["tp_size"], inst["pp_size"],
                                        inst["local_ep"], inst["ep_total"], inst["pd_type"],
-                                       nid, inst_id, max_num_batched_tokens, max_num_seqs, placement[inst_id], block_mode_on[inst_id],
-                                       expert_routing_policy, enable_prefix_caching, enable_attn_offloading,
+                                       nid, inst_id,
+                                       inst_cfg["max_num_batched_tokens"], inst_cfg["max_num_seqs"],
+                                       placement[inst_id], block_mode_on[inst_id],
+                                       expert_routing_policy, inst_cfg["enable_prefix_caching"],
+                                       inst_cfg["enable_attn_offloading"],
                                        power_model, pim_models[nid],
-                                       enable_sub_batch_interleaving, fp, dtype=dtype, kv_cache_dtype=kv_cache_dtype,
+                                       inst_cfg["enable_sub_batch_interleaving"], inst_cfg["fp"],
+                                       dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
                                        tp_dim=inst.get("tp_dim"), ep_dim=inst.get("ep_dim"),
-                                       dp_sum_total_len=sum_total_len, enable_block_copy=enable_block_copy)
+                                       dp_sum_total_len=sum_total_len,
+                                       enable_block_copy=inst_cfg["enable_block_copy"])
                         generate_graph(batch, inst["hardware"], inst["num_npus"], nid,
-                                       inst_id, inst2npu_mapping[inst_id], enable_local_offloading,
+                                       inst_id, inst2npu_mapping[inst_id],
+                                       inst_cfg["enable_local_offloading"],
                                        workload_name=dp_workload_name)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
@@ -571,16 +637,23 @@ def main():
                         for inst_id in dp_groups[dg]:
                             batch, nid = dp_pending[dg][inst_id]
                             inst = instances[inst_id]
+                            inst_cfg = instance_runtime_configs[inst_id]
                             generate_trace(batch, inst["hardware"], inst["tp_size"], inst["pp_size"],
                                            inst["local_ep"], inst["ep_total"], inst["pd_type"],
-                                           nid, inst_id, max_num_batched_tokens, max_num_seqs, placement[inst_id], block_mode_on[inst_id],
-                                           expert_routing_policy, enable_prefix_caching, enable_attn_offloading,
+                                           nid, inst_id,
+                                           inst_cfg["max_num_batched_tokens"], inst_cfg["max_num_seqs"],
+                                           placement[inst_id], block_mode_on[inst_id],
+                                           expert_routing_policy, inst_cfg["enable_prefix_caching"],
+                                           inst_cfg["enable_attn_offloading"],
                                            power_model, pim_models[nid],
-                                           enable_sub_batch_interleaving, fp, dtype=dtype, kv_cache_dtype=kv_cache_dtype,
+                                           inst_cfg["enable_sub_batch_interleaving"], inst_cfg["fp"],
+                                           dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
                                            tp_dim=inst.get("tp_dim"), ep_dim=inst.get("ep_dim"),
-                                           dp_sum_total_len=sum_total_len, enable_block_copy=enable_block_copy)
+                                           dp_sum_total_len=sum_total_len,
+                                           enable_block_copy=inst_cfg["enable_block_copy"])
                             generate_graph(batch, inst["hardware"], inst["num_npus"], nid,
-                                           inst_id, inst2npu_mapping[inst_id], enable_local_offloading,
+                                           inst_id, inst2npu_mapping[inst_id],
+                                           inst_cfg["enable_local_offloading"],
                                            workload_name=dp_workload_name)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
@@ -596,15 +669,21 @@ def main():
                         responded = True
                 else:
                     # Independent instance: generate trace immediately
+                    inst_cfg = instance_runtime_configs[instance_id]
                     generate_trace(new_req, instance["hardware"], instance["tp_size"], instance["pp_size"],
                                    instance["local_ep"], instance["ep_total"],
                                    instance["pd_type"],
-                                   node_id, instance_id, max_num_batched_tokens, max_num_seqs, placement[instance_id], block_mode_on[instance_id],
-                                   expert_routing_policy, enable_prefix_caching, enable_attn_offloading, power_model, pim_models[node_id],
-                                   enable_sub_batch_interleaving, fp, dtype=dtype, kv_cache_dtype=kv_cache_dtype,
-                                   enable_block_copy=enable_block_copy)
+                                   node_id, instance_id,
+                                   inst_cfg["max_num_batched_tokens"], inst_cfg["max_num_seqs"],
+                                   placement[instance_id], block_mode_on[instance_id],
+                                   expert_routing_policy, inst_cfg["enable_prefix_caching"],
+                                   inst_cfg["enable_attn_offloading"], power_model, pim_models[node_id],
+                                   inst_cfg["enable_sub_batch_interleaving"], inst_cfg["fp"],
+                                   dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
+                                   enable_block_copy=inst_cfg["enable_block_copy"])
                     generate_graph(new_req, instance["hardware"], instance["num_npus"], node_id,
-                                   instance_id, inst2npu_mapping[instance_id], enable_local_offloading)
+                                   instance_id, inst2npu_mapping[instance_id],
+                                   inst_cfg["enable_local_offloading"])
                     workload = get_workload(new_req, instance["hardware"], instance_id)
                     controller.write_flush(p, workload)
             elif new_req is not None:
@@ -650,7 +729,7 @@ def main():
                     f"Each NPU Memory Usage {npu_used_mb:.2f} MB "
                     f"({npu_util:.3f} % Used)"
                 )
-                if enable_prefix_caching:
+                if schedulers[inst_id].enable_prefix_caching:
                     line += schedulers[inst_id].memory.npu_prefix_cache.format_prefix_info()
                 print_markup(line)
 
@@ -660,7 +739,7 @@ def main():
                 for i, (node_id, inst_ids) in enumerate(node2inst_mapping.items()):
                     node_cpu_usage = 0
                     inst_usage = []
-                    if enable_prefix_sharing and prefix_storage == "CPU":
+                    if any_prefix_caching and enable_prefix_sharing and prefix_storage == "CPU":
                         node_cpu_usage = prefix_pools[node_id].total_size() * prefix_pools[node_id].kv_size
                     else:
                         for inst_id in inst_ids:
@@ -676,10 +755,10 @@ def main():
                         f"Total CPU Memory Usage {node_cpu_usage/MB_TO_BYTE:.2f} MB, "
                         f"{cpu_util:.3f} % Used "
                     )
-                    if enable_prefix_caching and enable_prefix_sharing and prefix_storage == "CPU":
+                    if any_prefix_caching and enable_prefix_sharing and prefix_storage == "CPU":
                         line += prefix_pools[node_id].format_prefix_info()
 
-                    if (enable_prefix_sharing and prefix_storage == "CPU") or (len(inst_ids) == 1):
+                    if (any_prefix_caching and enable_prefix_sharing and prefix_storage == "CPU") or (len(inst_ids) == 1):
                         print_markup(line)
                     else:
                         parts = []
@@ -689,7 +768,7 @@ def main():
                         print_markup(line + "(" + ", ".join(parts) + ")")
 
             ######### Per CXL Metrics #########
-            if prefix_storage == "CXL":
+            if any_prefix_caching and prefix_storage == "CXL":
                 if enable_prefix_sharing:
                     num_prefix_pool = len(prefix_pools)
                     for cxl_id, cxl_pool in enumerate(prefix_pools):
@@ -703,18 +782,24 @@ def main():
                             f"{cxl_usage/MB_TO_BYTE:.2f}MB, {cxl_util:.3f} % Used"
                         )
                 else:
-                    # else only one instance could explictly use CXL
-                    inst_id = 0
-                    second_tier = schedulers[inst_id].memory.second_tier_prefix_cache
-                    cxl_usage = second_tier.total_size() * second_tier.kv_size
-                    cxl_util = cxl_usage / second_tier.capacity
-                    if not power_modeling:
-                        tree_indent = '└─'
-                    print_markup(
-                        f"{log_indent+tree_indent}CXL\\[0]: "
-                        f"Total CXL Device Memory Usage {cxl_usage / MB_TO_BYTE:.2f} MB, "
-                        f"{cxl_util:.3f} % Used"
-                    )
+                    enabled_inst_ids = [
+                        inst_id for inst_id, sched in enumerate(schedulers)
+                        if sched.enable_prefix_caching
+                    ]
+                    for pos, inst_id in enumerate(enabled_inst_ids):
+                        second_tier = getattr(
+                            schedulers[inst_id].memory, "second_tier_prefix_cache", None)
+                        if second_tier is None:
+                            continue
+                        cxl_usage = second_tier.total_size() * second_tier.kv_size
+                        cxl_util = cxl_usage / second_tier.capacity
+                        if not power_modeling and pos == len(enabled_inst_ids) - 1:
+                            tree_indent = '└─'
+                        print_markup(
+                            f"{log_indent+tree_indent}CXL\\[0]/Instance\\[{inst_id}]: "
+                            f"Total CXL Device Memory Usage {cxl_usage / MB_TO_BYTE:.2f} MB, "
+                            f"{cxl_util:.3f} % Used"
+                        )
 
             ######### Power Modeling #########
             if power_modeling:
@@ -789,8 +874,10 @@ def main():
     total_requested_tokens = 0
     total_npu_hit_tokens = 0
     total_cpu_hit_tokens = 0
-    if enable_prefix_caching:
+    if any_prefix_caching:
         for i in range(num_instances):
+            if not schedulers[i].enable_prefix_caching:
+                continue
             (temp_npu_a, temp_npu_b), (temp_cpu_a, temp_cpu_b) = schedulers[i].memory.return_prefix_info()
             if (not enable_prefix_sharing) and (prefix_storage != "None") and (temp_npu_a != temp_cpu_a):
                 raise RuntimeError(f"Instance[{i}] prefix caching requested tokens mismatch between NPU ({temp_npu_a}) and CPU ({temp_cpu_a})")
@@ -821,7 +908,7 @@ def main():
     print_markup(f"Total token throughput (tok/s):                                     {(total_prompt + total_gen)/total_latency:.2f}")
     print_markup(f"Throughput per {1/RATIO} sec (\\[prompt_throughput], \\[gen_throughput]): {throughput}")
     print_rule()
-    if enable_prefix_caching:
+    if any_prefix_caching:
         print_rule("[sim.tagline]Prefix Caching Results[/]")
         print_markup(f"Total requested prompt tokens:                                      {total_requested_tokens}")
         print_markup(f"NPU prefix hit prompt tokens:                                       {total_npu_hit_tokens}")

--- a/serving/core/router.py
+++ b/serving/core/router.py
@@ -53,32 +53,47 @@ class Router:
     # Instance selection policies
     # -----------------------------------------------------------------------
 
-    def _rr_select(self, num_instances):
-        idx = self.prefill_rr_counter % num_instances
-        self.prefill_rr_counter += 1
+    def _get_counter(self, role):
+        return self.decode_rr_counter if role == "decode" else self.prefill_rr_counter
+
+    def _set_counter(self, role, value):
+        if role == "decode":
+            self.decode_rr_counter = value
+        else:
+            self.prefill_rr_counter = value
+
+    def _rr_select(self, schedulers, role):
+        num_instances = len(schedulers)
+        idx = self._get_counter(role) % num_instances
+        self._set_counter(role, idx + 1)
         return idx
 
-    def _rand_select(self, num_instances):
-        return self._rnd.randrange(num_instances)
+    def _rand_select(self, schedulers, role):
+        return self._rnd.randrange(len(schedulers))
 
-    def _least_load_select(self, num_instances):
-        """vLLM-style least-loaded routing: score = waiting * 4 + running."""
+    def _least_load_select(self, schedulers, role):
+        """vLLM-style least-loaded routing, normalized by instance capacity."""
         best_idx = 0
         best_score = float('inf')
-        start = self.prefill_rr_counter % num_instances
+        num_instances = len(schedulers)
+        start = self._get_counter(role) % num_instances
         for offset in range(num_instances):
             idx = (start + offset) % num_instances
-            sched = self.prefill_schedulers[idx]
+            sched = schedulers[idx]
             waiting = len(sched.request)
             running = sum(len(b.requests) for b in sched.inflight)
-            score = waiting * 4 + running
+            raw_score = waiting * 4 + running
+            capacity = getattr(sched, "max_num_seqs", 0)
+            score = raw_score
+            if capacity not in (0, float('inf')):
+                score = raw_score / capacity
             if score < best_score:
                 best_score = score
                 best_idx = idx
-        self.prefill_rr_counter = (best_idx + 1) % num_instances
+        self._set_counter(role, (best_idx + 1) % num_instances)
         return best_idx
 
-    def _custom_select(self, num_instances):
+    def _custom_select(self, schedulers, role):
         raise NotImplementedError("Implement custom routing policy.")
 
     # -----------------------------------------------------------------------
@@ -183,21 +198,21 @@ class Router:
             if req_data['arrival_time_ns'] > current_time_ns:
                 break
 
-            instance_id = self._select_instance(self.prefill_instances)
+            instance_id = self._select_instance(self.prefill_schedulers, "prefill")
             sched = self.prefill_schedulers[instance_id]
 
-            if self._enable_prefix_caching:
+            if sched.enable_prefix_caching:
                 sched.add_request([
                     req_data['index'], sched.model,
                     req_data['input_toks'], req_data['output_toks'],
-                    req_data['arrival_time_ns'], instance_id,
-                    req_data['input_hash_ids'], req_data['output_hash_ids'],
+                    req_data['arrival_time_ns'], sched.instance_id,
+                    req_data.get('input_hash_ids', []), req_data.get('output_hash_ids', []),
                 ], is_init=self._is_init)
             else:
                 sched.add_request([
                     req_data['index'], sched.model,
                     req_data['input_toks'], req_data['output_toks'],
-                    req_data['arrival_time_ns'], instance_id,
+                    req_data['arrival_time_ns'], sched.instance_id,
                 ], is_init=self._is_init)
 
             self._pending_idx += 1
@@ -308,5 +323,5 @@ class Router:
 
     def transfer_prefill_request(self, requests):
         for req in requests:
-            instance_id = self._select_instance(self.decode_instances)
+            instance_id = self._select_instance(self.decode_schedulers, "decode")
             self.decode_schedulers[instance_id].add_decode(req)


### PR DESCRIPTION
related to #36 

## Add per-instance runtime config overrides

### Background

ServingSim already supports multiple `instance`s in a cluster config, but several runtime options were previously only configurable through global CLI arguments, including:

* `max_num_seqs`
* `max_num_batched_tokens`
* `dtype`
* `kv_cache_dtype`
* chunked prefill
* prefix caching
* offloading-related options

This works for homogeneous deployments, where all instances represent identical vLLM replicas. However, it is not flexible enough for simulating multiple independent vLLM engines with different runtime configurations.

This PR adds per-instance runtime config overrides while keeping the existing CLI-based behavior compatible.

### Summary

This PR adds per-instance runtime config parsing and propagates the resolved instance-specific config through scheduling, trace generation, graph generation, routing, and prefix-cache-related logging/statistics.

The effective priority is:

_instances[i] field > CLI argument > model config dtype fallback_


If a field is not specified in an instance config, the existing global CLI value is still used.

### Main changes

#### 1. Per-instance runtime config parsing

This PR adds a unified per-instance runtime config resolution path in `serving/__main__.py`.

Each instance now gets its own resolved runtime config. Supported per-instance fields include:

* `max_num_seqs`
* `max_num_batched_tokens`
* `long_prefill_token_threshold`
* `block_size`
* `dtype`
* `kv_cache_dtype`
* `enable_chunked_prefill`
* `enable_prefix_caching`
* `prioritize_prefill`
* `enable_local_offloading`
* `enable_attn_offloading`
* `enable_sub_batch_interleaving`
* `enable_block_copy`

The existing semantics of `max_num_seqs=0` and `max_num_batched_tokens=0` are preserved, where `0` is converted to `inf`.

Dtype fallback is also changed to be instance-aware. Instead of globally inferring dtype from the first model, each instance now falls back based on its own `model_name` and the corresponding model config.

#### 2. Scheduler now receives instance-specific configs

Previously, every scheduler was created with the same global runtime values.

Now each scheduler is constructed using the resolved config for its own instance, including:

* `max_num_seqs`
* `max_num_batched_tokens`
* `fp`
* `block_size`
* `enable_prefix_caching`
* `enable_chunked_prefill`
* `kv_cache_dtype`

The scheduler logic itself is mostly unchanged; the main difference is that its inputs are now per-instance instead of globally shared.

#### 3. Trace and graph generation use per-instance configs

This PR updates `generate_trace()` so that trace generation also uses the resolved per-instance runtime config.

This includes:

* runtime max token / sequence limits
* dtype / KV cache dtype
* tensor size calculation
* attention offloading
* sub-batch interleaving
* block copy

`generate_graph()` is also updated to use the per-instance `enable_local_offloading` setting.

This makes the generated trace and graph consistent with the scheduler configuration of each instance.

#### 4. Prefix cache handling is now instance-aware

Since prefix caching can now be enabled for some instances and disabled for others, this PR removes the assumption that prefix caching is a single global switch.

The request-loading path now only loads token ids when at least one instance needs prefix caching.

When a request is actually assigned, the router checks the target scheduler’s own `enable_prefix_caching` flag.

Prefix cache logging and final statistics are also updated to only access schedulers where prefix caching is enabled.

For shared prefix pools, this PR keeps the requirement that shared instances should have compatible `model_name`, `dtype/fp`, and `kv_cache_dtype`, since KV size calculation depends on these values.

#### 5. Router changes for heterogeneous instances

This PR updates router selection so that it works better with heterogeneous instances.

The `LOAD` strategy now normalizes load by instance capacity:


`score = (waiting * 4 + running) / max_num_seqs`


This avoids treating a small-capacity instance and a large-capacity instance as equivalent.

This PR also fixes the P/D decode selection path so that decode selection is performed over the decode scheduler list. Request metadata now records the actual `sched.instance_id`, which avoids issues when scheduler-list index and global instance id do not match.

#### 6. Offloading config handling

`config_builder` still takes global offloading flags, but this PR pre-reads the raw cluster config before building the cluster config.

If either the CLI or any instance enables local / attention offloading, the builder will generate the corresponding lower-level ASTRA-Sim resources.

This allows per-instance trace generation to enable offloading while keeping compatibility with the current builder interface.

### Testing

Both the existing CLI-only path and the new per-instance override path were tested.

#### Basic checks

Commands:

```
source /opt/venv/astra-sim/bin/activate && python -m json.tool configs/cluster/single_node_pd_per_instance_config.json >/dev/null

source /opt/venv/astra-sim/bin/activate && python -m py_compile serving/__main__.py serving/core/router.py

source /opt/venv/astra-sim/bin/activate && python -m serving --help | head -n 10

git diff --check
```

Result: all passed.

#### Backward compatibility test

An old-style single-instance config without per-instance overrides was tested:

```
source /opt/venv/astra-sim/bin/activate && python -m serving \
  --cluster-config configs/cluster/single_node_single_instance.json \
  --dataset workloads/example_trace.jsonl \
  --num-reqs 1 \
  --dtype bfloat16 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 1 \
  --log-interval 0.5
```

Result: simulation completed successfully with exit code 0.

Verification:

The old config does not specify instance-level overrides, so the CLI value `--max-num-batched-tokens 1` should still control scheduling.

The generated trace contains:

```
embedding_0 ... input_size 4
```

Since embedding input size is `tokens * 4`, this means the first prefill chunk contains only 1 token.

This confirms that the old CLI-only behavior is preserved.

#### Per-instance override test

The new P/D per-instance config was tested:

```
source /opt/venv/astra-sim/bin/activate && python -m serving \
  --cluster-config configs/cluster/single_node_pd_per_instance_config.json \
  --dataset workloads/example_trace.jsonl \
  --num-reqs 1 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 1 \
  --log-interval 0.5
```

Result: P/D simulation completed successfully with exit code 0.

Key verification points:

* The CLI still passes `--max-num-batched-tokens 1`.
* The prefill instance overrides `max_num_batched_tokens` to `8192` in the cluster config.
* Runtime log shows:

```
max-num-batched-tokens=8192 exceeds profiled 2048
```

The generated prefill trace contains:

```
PREFILL
embedding_0 ... input_size 40
```

Since `40 = 10 tokens * 4`, this confirms that the first prefill batch processes the full 10-token prompt instead of being limited by the CLI value of 1.

The decode trace still contains:

```
DECODE
embedding_0 ... input_size 4
```

This confirms that decode still runs one token per step, and the P/D handoff plus decode instance path work as expected.

### Test conclusion

* Old configs without instance-level override fields still use CLI arguments as before.
* New configs with instance-level override fields correctly use per-instance scheduler and trace-generation configs.
* The smoke tests cover both the old single-instance path and the new P/D per-instance path.

### Known limitations / follow-up work

There are a few boundaries left for follow-up work.

First, P/D pool compatibility is not fully validated yet. In practice, fields such as `block_size`, `kv_cache_dtype`, and `model_name` should probably be checked more strictly across related prefill/decode instances. A mismatched config may still run, but the simulation semantics may not be reliable.

Second, `enable_attn_offloading` and `enable_local_offloading` can now be controlled per instance for trace/graph behavior, but the lower-level `config_builder` still uses a global-style decision: if either the CLI or any instance enables offloading, the corresponding ASTRA-Sim resources are generated.

This is sufficient for the current single-node use case, but more fine-grained builder support may be needed later for multi-node heterogeneous PIM/offloading configurations.
