### PR TITLE
fix: fix non-DP multi-instance collective scoping in ASTRA-Sim traces

### DIFF
--- a/configs/cluster/single_node_4_instance_2TP.json
+++ b/configs/cluster/single_node_4_instance_2TP.json
@@ -1,0 +1,61 @@
+{
+    "num_nodes": 1,
+    "link_bw": 16,
+    "link_latency": 20000,
+    "nodes": [
+        {
+            "num_instances": 4,
+            "cpu_mem": {
+                "mem_size": 512,
+                "mem_bw": 256,
+                "mem_latency": 0
+            },
+            "instances": [
+                {
+                    "model_name": "meta-llama/Llama-3.1-8B",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "pd_type": null,
+                    "tp_size": 2
+                },
+                {
+                    "model_name": "meta-llama/Llama-3.1-8B",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "pd_type": null,
+                    "tp_size": 2
+                },
+                {
+                    "model_name": "meta-llama/Llama-3.1-8B",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "pd_type": null,
+                    "tp_size": 2
+                },
+                {
+                    "model_name": "meta-llama/Llama-3.1-8B",
+                    "hardware": "RTXPRO6000",
+                    "npu_mem": {
+                        "mem_size": 96,
+                        "mem_bw": 1597,
+                        "mem_latency": 0
+                    },
+                    "pd_type": null,
+                    "tp_size": 2
+                }
+            ]
+        }
+    ]
+}

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -680,6 +680,7 @@ def main():
                                    inst_cfg["enable_attn_offloading"], power_model, pim_models[node_id],
                                    inst_cfg["enable_sub_batch_interleaving"], inst_cfg["fp"],
                                    dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
+                                   tp_dim=instance["tp_dim"], ep_dim=instance["ep_dim"],
                                    enable_block_copy=inst_cfg["enable_block_copy"])
                     generate_graph(new_req, instance["hardware"], instance["num_npus"], node_id,
                                    instance_id, inst2npu_mapping[instance_id],

--- a/serving/core/config_builder.py
+++ b/serving/core/config_builder.py
@@ -144,14 +144,21 @@ def _resolve_dp_groups(all_instances):
             m["tp_dim"] = tp_dim
             m["ep_dim"] = ep_dim
 
-    # Non-DP instances
+    # Non-DP instances. Independent multi-instance configs still use a
+    # multi-dimensional topology ([tp_size, num_groups]); local collectives
+    # must be scoped to dim 0 so they do not cross instance/PP groups.
+    network_dims = _compute_network_dims(all_instances)
+    local_dim = None
+    if len(network_dims) > 1:
+        local_dim = [True] + [False] * (len(network_dims) - 1)
+
     for inst in all_instances:
         if inst.get("dp_group") is None:
             inst["dp_group_size"] = 1
             inst["local_ep"] = inst["ep_size"]
             inst["ep_total"] = inst["ep_size"]
-            inst["tp_dim"] = None
-            inst["ep_dim"] = None
+            inst["tp_dim"] = local_dim
+            inst["ep_dim"] = local_dim if inst["ep_size"] > 1 else None
 
 
 def _compute_network_dims(instances):

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -962,7 +962,8 @@ def _emit_layer(ctx, bctx, layer_name, lines, power_acc, batch_tag='NONE', layer
         if wt_loc != 'LOCAL':
             power_acc.dram_weight_bytes += wt
         if comm_size > 0:
-            power_acc.link_data_bytes += total_ring_data(comm_size, ctx.tp_size, collective=comm_type.lower())
+            collective = comm_type.split(':', 1)[0].lower()
+            power_acc.link_data_bytes += total_ring_data(comm_size, ctx.tp_size, collective=collective)
 
     return latency_ns
 


### PR DESCRIPTION
### 🐛 Bug Fix: Fix Non-DP Multi-Instance Collective Scoping

#### 🛑 Problem (Why this is needed)
Under a non-DP multi-instance configuration (e.g., `configs/cluster/single_node_4_instance_2TP.json` with 4 independent instances, each having `tp_size=2`), the topology is derived as `[2, 4]`. Here, `dim0` represents the intra-instance TP dimension, and `dim1` represents the instance/group dimension. TP `ALLREDUCE` should only execute within `dim0` and must never cross `dim1`.

The legacy codebase suffered from the following issues:
1. The DP group branch explicitly configured `tp_dim=[True, False]`, but the non-DP instance branch left `tp_dim` as `None`.
2. The independent instance code path omitted passing `tp_dim`/`ep_dim` to `generate_trace()`.
3. Consequently, the generated trace fell back to a bare `ALLREDUCE`. In ASTRA-Sim, a collective without explicit `involved_dim` defaults to involving all dimensions. Under the `[2, 4]` topology, this mistakenly expanded the TP `ALLREDUCE` across instance dimensions, generating **phantom cross-instance collectives**.

#### 🛠️ Solution & Implementation Details
This PR restricts the TP/EP collective scoped scope within `dim0` for independent multi-instance topologies, preventing phantom communications from bleeding into cross-instance/PP dimensions:

- **`serving/core/config_builder.py:147`**: Updated parallelism resolution for non-DP instances. For an independent multi-instance topology `[tp_size, num_groups]`, it now automatically generates a local collective scope: `local_dim = [True] + [False] * (len(network_dims) - 1)`. Non-DP instances will now set `inst["tp_dim"] = local_dim` and `inst["ep_dim"] = local_dim if inst["ep_size"] > 1 else None`.
- **`serving/__main__.py:767`**: Fixed the `generate_trace()` invocation for independent instances. While the DP branch already forwarded `tp_dim`/`ep_dim`, the non-DP independent branch missed it. This parameter passing is now added to ensure deduced scopes are channeled into the trace generator.
- **`serving/core/trace_generator.py:965`**: Fixed power/link stat tracking for scoped collectives. Since `comm_type` can now appear as `ALLREDUCE:1,0`, `total_ring_data()` (which only accepts raw collective names like `allreduce`/`allgather`) would error out. The scope suffix is now stripped via `comm_type.split(':', 1)[0].lower()` prior to the invocation.

#### 🧪 Verification & Testing
- Validated compilation via: `python -m py_compile serving/__main__.py serving/core/config_builder.py serving/core/trace_generator.py`
- Re-generated traces using `configs/cluster/single_node_4_instance_2TP.json`. Confirmed that the output now correctly restricts the dimension by emitting `ALLREDUCE:1,0`, while the global network topology remains unchanged at `npus_count: [2, 4]`. This verifies that the fix accurately isolates the TP collective scope without impacting the cluster topology.

#### 🎯 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
