### PR TITLE
feat: add run-isolated ASTRA-Sim input paths

### DIFF
--- a/docs/docs/examples/advanced/sub-batch-interleaving.md
+++ b/docs/docs/examples/advanced/sub-batch-interleaving.md
@@ -90,7 +90,7 @@ column set.
   interleaving silently no-ops (you can't split a single request
   into two halves without breaking the per-request semantics).
 - **Trace tags.** If you read the generated trace file
-  (`astra-sim/inputs/trace/...`), each layer carries a `BATCH_1`
+  (`astra-sim/inputs/runs/<run_id>/trace/...`), each layer carries a `BATCH_1`
   or `BATCH_2` misc tag instead of the usual `NONE`. Confirms
   interleaving is actually emitted.
 

--- a/docs/docs/reference/cli-flags.md
+++ b/docs/docs/reference/cli-flags.md
@@ -64,7 +64,18 @@ matching runtime knobs per `instances[i]`; see
 | --- | --- | --- | --- |
 | `--dataset` | path | `None` | JSONL workload file. See **[Workloads → JSONL format](/docs/workloads/jsonl-format)** |
 | `--num-reqs` | int | `0` | Entries to load from the dataset (`0` = all). For agentic, each entry is a session |
-| `--output` | path | `None` | Per-request CSV output path. Stdout only if `None` |
+| `--output` | path | `None` | Per-request CSV output path. Stdout only if `None`. The literal `{run_id}` is replaced with the active run id |
+
+## Run isolation
+
+Each invocation writes ASTRA-Sim intermediates under a run-specific input
+root so parallel simulations do not overwrite each other's generated
+configs, traces, or Chakra workloads.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--run-id` | string | auto-generated | Path-safe id for this simulation run. Used in `astra-sim/inputs/runs/<run-id>` and the `{run_id}` output placeholder |
+| `--inputs-root` | path | `astra-sim/inputs/runs/<run-id>` | Override the generated ASTRA-Sim input root, for example to place intermediates on local SSD or tmpfs |
 
 ## Logging
 

--- a/docs/docs/reference/trace-format.md
+++ b/docs/docs/reference/trace-format.md
@@ -16,10 +16,11 @@ For the *internals* of how this trace is produced, see
 ## File location
 
 ```
-astra-sim/inputs/trace/<hardware>/<model>/instance_<i>_batch_<b>.txt
+astra-sim/inputs/runs/<run_id>/trace/<hardware>/<model>/instance_<i>_batch_<b>.txt
 ```
 
-One file per (instance × batch). Regenerated every iteration.
+One file per (instance × batch), under the run-specific ASTRA-Sim input
+root. Regenerated every iteration.
 
 ## File structure
 

--- a/docs/docs/simulator/architecture.mdx
+++ b/docs/docs/simulator/architecture.mdx
@@ -163,10 +163,10 @@ Concretely:
 1. The Python scheduler decides which requests run this iteration and
    produces a `Batch`.
 2. `trace_generator` writes a per-layer text trace to
-   `astra-sim/inputs/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
+   `astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
 3. `graph_generator` shells out to the Chakra converter, producing a
    protobuf graph at
-   `astra-sim/inputs/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
+   `astra-sim/inputs/runs/<run_id>/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
 4. `controller.write_flush(process, "<workload-path>")` sends that
    path over stdin.
 5. ASTRA-Sim reads the `.et` file, executes the compute + comm graph,

--- a/docs/docs/simulator/request-lifecycle.md
+++ b/docs/docs/simulator/request-lifecycle.md
@@ -161,14 +161,14 @@ profile DB:
   TP=1.
 
 The output is a tab-separated text trace at
-`astra-sim/inputs/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
+`astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
 Full mechanics on **[Trace generation](./trace-generation)**.
 
 ## Stage 7, Converted to Chakra graph
 
 `graph_generator.generate_graph` shells out to Chakra's text→protobuf
 converter, producing
-`astra-sim/inputs/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
+`astra-sim/inputs/runs/<run_id>/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
 
 The Chakra converter creates:
 

--- a/serving/README.md
+++ b/serving/README.md
@@ -164,8 +164,8 @@ matching `sequence:` rather than editing this file.
 
 ### `config_builder.py`
 Parses the user-provided cluster config JSON from `configs/cluster/` and generates the
-ASTRA-Sim input files: `astra-sim/inputs/network/network.yml`,
-`astra-sim/inputs/memory/memory_expansion.json`, and `astra-sim/inputs/system/system.json`.
+ASTRA-Sim input files under `astra-sim/inputs/runs/<run_id>/`: `network/network.yml`,
+`memory/memory_expansion.json`, and `system/system.json`.
 For DP groups, generates a 2D network topology `[tp_size, dp_group_size]` and sets
 `system.json` collective implementations to match the number of topology dimensions.
 Computes `tp_dim`/`ep_dim` per instance for `involved_dim` scoping.

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -25,6 +25,7 @@ from serving.core.config_builder import *
 from serving.core.router import *
 from serving.core.power_model import *
 from serving.core.logger import *
+from serving.core.run_paths import build_run_paths, resolve_run_id
 import sys as flush
 
 from pyinstrument import Profiler
@@ -73,6 +74,44 @@ def _cluster_config_path(path):
 def _load_cluster_config_for_overrides(path):
     with open(_cluster_config_path(path), "r") as f:
         return json.load(f)
+
+
+def _resolve_output_file(path, run_id):
+    if path is None:
+        return None
+    return path.replace("{run_id}", run_id)
+
+
+def _prepare_ns3_config(astra_sim, run_paths):
+    template = os.path.join(astra_sim, "extern/network_backend/ns-3/scratch/config/config.txt")
+    output_dir = os.path.join(run_paths.inputs_root, "ns3", "output")
+    config_path = os.path.join(run_paths.inputs_root, "ns3", "config.txt")
+    os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
+    replacements = {
+        "FLOW_FILE": os.path.join(output_dir, "flow.txt"),
+        "TRACE_FILE": os.path.join(output_dir, "trace.txt"),
+        "TRACE_OUTPUT_FILE": os.path.join(output_dir, "mix.tr"),
+        "FCT_OUTPUT_FILE": os.path.join(output_dir, "fct.txt"),
+        "PFC_OUTPUT_FILE": os.path.join(output_dir, "pfc.txt"),
+        "QLEN_MON_FILE": os.path.join(output_dir, "qlen.txt"),
+    }
+
+    for path in (replacements["FLOW_FILE"], replacements["TRACE_FILE"]):
+        open(path, "w").close()
+
+    with open(template, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    with open(config_path, "w", encoding="utf-8") as f:
+        for line in lines:
+            parts = line.split(maxsplit=1)
+            if parts and parts[0] in replacements:
+                f.write(f"{parts[0]} {replacements[parts[0]]}\n")
+            else:
+                f.write(line)
+    return config_path
 
 
 def _iter_raw_instances(cluster_config):
@@ -210,7 +249,13 @@ def main():
                         'If None, requests must be added manually in serving/__main__.py')
     parser.add_argument('--output', type=str, default=None,
                         help='path for per-request CSV output with latency metrics (TTFT, TPOT, ITL). '
-                        'If None, results are printed to stdout only')
+                        'If None, results are printed to stdout only. Supports {run_id} placeholder')
+    parser.add_argument('--run-id', type=str, default=None,
+                        help='unique id for this simulation run. Intermediate ASTRA-Sim inputs are written under '
+                        'astra-sim/inputs/runs/<run-id>. If omitted, a process-unique id is generated')
+    parser.add_argument('--inputs-root', type=str, default=None,
+                        help='override the root directory for generated ASTRA-Sim inputs. Defaults to '
+                        'astra-sim/inputs/runs/<run-id>')
     parser.add_argument('--skip-prefill', action='store_true', default=False,
                         help='skip the prefill phase, running decode only')
     parser.add_argument('--num-reqs', type=int, default=0,
@@ -228,6 +273,11 @@ def main():
 
     args = parser.parse_args()
     
+    args.run_id = resolve_run_id(args.run_id)
+    run_paths = build_run_paths(astra_sim, args.run_id, args.inputs_root)
+    args.inputs_root = run_paths.inputs_root
+    args.output = _resolve_output_file(args.output, args.run_id)
+
     configure_logger(level=args.log_level)
     logger = get_logger("Main")
     print_banner()
@@ -254,7 +304,8 @@ def main():
         inst.get("enable_attn_offloading", False) for inst in raw_instances)
     # ---------------------------------- Extract cluster config -----------------------------------
     cluster = build_cluster_config(
-        astra_sim, args.cluster_config, build_enable_local_offloading, build_enable_attn_offloading)
+        astra_sim, args.cluster_config, build_enable_local_offloading, build_enable_attn_offloading,
+        inputs_root=run_paths.inputs_root)
     num_nodes = cluster["num_nodes"]
     num_instances = cluster["num_instances"]
     instances = cluster["instances"]
@@ -278,20 +329,15 @@ def main():
     # Automatic network, memory configuration
     # If you want to set more specific information such as latency, look at config.py and each json file
     if network_backend == 'analytical':
-        network=os.path.join(astra_sim, "inputs/network/network.yml")
+        network=run_paths.network_config
         binary=os.path.join(astra_sim, "build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra")
     elif network_backend == 'ns3':
-        network=os.path.join(astra_sim, "extern/network_backend/ns-3/scratch/config/config.txt")
+        network=_prepare_ns3_config(astra_sim, run_paths)
         binary=os.path.join(astra_sim, "extern/network_backend/ns-3/build/scratch/ns3.42-AstraSimNetwork-default")
-        # make output files
-        output_dir = os.path.join(astra_sim, "extern/network_backend/ns-3/scratch/output")
-        os.makedirs(output_dir, exist_ok=True)
-        open(os.path.join(output_dir, "flow.txt"), "w").close()
-        open(os.path.join(output_dir, "trace.txt"), "w").close()
     else:
         raise NotImplementedError("Only analytical and ns3 network backend are supported")
-    memory=os.path.join(astra_sim, 'inputs/memory/memory_expansion.json')
-    system=os.path.join(astra_sim, "inputs/system/system.json")
+    memory=run_paths.memory_config
+    system=run_paths.system_config
     # ------------------------------------- Prepare simulation -------------------------------------
     # Need to extract each instance's memory accessability 
     node2inst_mapping = defaultdict(list)
@@ -445,11 +491,11 @@ def main():
         event_time = first_arival_time
     else:
         event_time = INTERVAL
-    generate_event(int(event_time))
+    generate_event(int(event_time), inputs_root=run_paths.inputs_root)
     # Make Chakra Grapth
-    generate_graph(None, None, total_npu, event=True)
+    generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root)
     # set first workload file
-    workload = get_workload(None, None, event=True)
+    workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
     args = [binary, "--workload-configuration="+workload, "--system-configuration="+system, "--network-configuration="+network, "--memory-configuration="+memory]
     if start_npu_ids != "":
@@ -588,18 +634,22 @@ def main():
                                        dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
                                        tp_dim=inst.get("tp_dim"), ep_dim=inst.get("ep_dim"),
                                        dp_sum_total_len=sum_total_len,
-                                       enable_block_copy=inst_cfg["enable_block_copy"])
+                                       enable_block_copy=inst_cfg["enable_block_copy"],
+                                       inputs_root=run_paths.inputs_root)
                         generate_graph(batch, inst["hardware"], inst["num_npus"], nid,
                                        inst_id, inst2npu_mapping[inst_id],
                                        inst_cfg["enable_local_offloading"],
-                                       workload_name=dp_workload_name)
+                                       workload_name=dp_workload_name,
+                                       inputs_root=run_paths.inputs_root)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
-                                                                    workload_name=dp_workload_name)
+                                                                    workload_name=dp_workload_name,
+                                                                    inputs_root=run_paths.inputs_root)
 
                     dp_pending[dg].clear()
                     workload = get_workload(dummy, instances[instance_id]["hardware"], instance_id,
-                                            workload_name=dp_workload_name)
+                                            workload_name=dp_workload_name,
+                                            inputs_root=run_paths.inputs_root)
                     controller.write_flush(p, workload)
                     responded = True
                 else:
@@ -650,18 +700,22 @@ def main():
                                            dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
                                            tp_dim=inst.get("tp_dim"), ep_dim=inst.get("ep_dim"),
                                            dp_sum_total_len=sum_total_len,
-                                           enable_block_copy=inst_cfg["enable_block_copy"])
+                                           enable_block_copy=inst_cfg["enable_block_copy"],
+                                           inputs_root=run_paths.inputs_root)
                             generate_graph(batch, inst["hardware"], inst["num_npus"], nid,
                                            inst_id, inst2npu_mapping[inst_id],
                                            inst_cfg["enable_local_offloading"],
-                                           workload_name=dp_workload_name)
+                                           workload_name=dp_workload_name,
+                                           inputs_root=run_paths.inputs_root)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
-                                                                        workload_name=dp_workload_name)
+                                                                        workload_name=dp_workload_name,
+                                                                        inputs_root=run_paths.inputs_root)
 
                         dp_pending[dg].clear()
                         workload = get_workload(new_req, instance["hardware"], instance_id,
-                                                workload_name=dp_workload_name)
+                                                workload_name=dp_workload_name,
+                                                inputs_root=run_paths.inputs_root)
                         controller.write_flush(p, workload)
                     else:
                         # Waiting for other DP members — send pass
@@ -681,15 +735,19 @@ def main():
                                    inst_cfg["enable_sub_batch_interleaving"], inst_cfg["fp"],
                                    dtype=inst_cfg["dtype"], kv_cache_dtype=inst_cfg["kv_cache_dtype"],
                                    tp_dim=instance["tp_dim"], ep_dim=instance["ep_dim"],
-                                   enable_block_copy=inst_cfg["enable_block_copy"])
+                                   enable_block_copy=inst_cfg["enable_block_copy"],
+                                   inputs_root=run_paths.inputs_root)
                     generate_graph(new_req, instance["hardware"], instance["num_npus"], node_id,
                                    instance_id, inst2npu_mapping[instance_id],
-                                   inst_cfg["enable_local_offloading"])
-                    workload = get_workload(new_req, instance["hardware"], instance_id)
+                                   inst_cfg["enable_local_offloading"],
+                                   inputs_root=run_paths.inputs_root)
+                    workload = get_workload(new_req, instance["hardware"], instance_id,
+                                            inputs_root=run_paths.inputs_root)
                     controller.write_flush(p, workload)
             elif new_req is not None:
                 # Non-first NPU: pick up existing batch workload
-                workload = get_workload(new_req, instances[instance_id]["hardware"], instance_id)
+                workload = get_workload(new_req, instances[instance_id]["hardware"], instance_id,
+                                        inputs_root=run_paths.inputs_root)
                 controller.write_flush(p, workload)
 
         # check time to store throughput (only print on start NPU to avoid transient states)

--- a/serving/core/config_builder.py
+++ b/serving/core/config_builder.py
@@ -3,6 +3,7 @@ import yaml
 import math
 import sys
 import os
+import shutil
 from .utils import get_config
 from .pim_model import PIMModel
 from .logger import get_logger
@@ -22,6 +23,33 @@ _COLLECTIVE_IMPL_KEYS = [
     "reduce-scatter-implementation",
     "all-to-all-implementation",
 ]
+
+
+def _prepare_input_config_paths(astra_sim, inputs_root):
+    if inputs_root is None:
+        inputs_root = os.path.join(astra_sim, "inputs")
+    inputs_root = os.path.abspath(inputs_root)
+
+    network_config_path = os.path.join(inputs_root, "network", "network.yml")
+    system_config_path = os.path.join(inputs_root, "system", "system.json")
+    memory_config_path = os.path.join(inputs_root, "memory", "memory_expansion.json")
+
+    for path in (network_config_path, system_config_path, memory_config_path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    default_system_config_path = os.path.join(astra_sim, "inputs", "system", "system.json")
+    if os.path.abspath(system_config_path) != os.path.abspath(default_system_config_path):
+        if not os.path.isfile(default_system_config_path):
+            raise FileNotFoundError(
+                f"ASTRA-Sim system config template '{default_system_config_path}' not found."
+            )
+        shutil.copyfile(default_system_config_path, system_config_path)
+    elif not os.path.isfile(system_config_path):
+        raise FileNotFoundError(
+            f"ASTRA-Sim system config '{system_config_path}' not found."
+        )
+
+    return inputs_root, network_config_path, system_config_path, memory_config_path
 
 
 def _resolve_parallelism(instance, model_config):
@@ -242,7 +270,7 @@ def _sync_system_collective_dims(system_config_path, instances):
 
 
 # parse cluster configuration from JSON file and build config file for astra-sim
-def build_cluster_config(astra_sim, cluster_config_path, enable_local_offloading=False, enable_attn_offloading=False):
+def build_cluster_config(astra_sim, cluster_config_path, enable_local_offloading=False, enable_attn_offloading=False, inputs_root=None):
     cluster_config_path = f'../{cluster_config_path}' # move out from astra-sim folder
     
     try:
@@ -255,9 +283,9 @@ def build_cluster_config(astra_sim, cluster_config_path, enable_local_offloading
         print(f"Failed to parse JSON from '{cluster_config_path}'.")
         exit(1)
 
-    network_config_path = os.path.join(astra_sim, 'inputs/network/network.yml')
-    system_config_path = os.path.join(astra_sim, 'inputs/system/system.json')
-    memory_config_path = os.path.join(astra_sim, 'inputs/memory/memory_expansion.json')
+    inputs_root, network_config_path, system_config_path, memory_config_path = (
+        _prepare_input_config_paths(astra_sim, inputs_root)
+    )
     memory_config = {}
 
     num_nodes = cluster_config["num_nodes"]
@@ -631,6 +659,10 @@ def build_cluster_config(astra_sim, cluster_config_path, enable_local_offloading
         "pim_models": pim_models,
         "link_bw": link_bw,
         "link_latency": link_latency,
+        "inputs_root": inputs_root,
+        "network_config_path": network_config_path,
+        "system_config_path": system_config_path,
+        "memory_config_path": memory_config_path,
     }
     # print("Current cluster : {}".format(cluster))
                 

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -3,14 +3,16 @@ import subprocess
 from time import time
 from .request import *
 from .logger import get_logger
+from .run_paths import input_path
 
 logger = get_logger("GraphGenerator")
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None):
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None):
 
     cwd = os.getcwd()
     chakra = os.path.join(cwd, "extern/graph_frontend/chakra")
-    os.chdir(chakra)
+    if inputs_root is None:
+        inputs_root = os.path.join(cwd, "inputs")
 
     if event:
         file_name = 'event_handler'
@@ -20,21 +22,23 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
     # For DP groups, all instances write .et files to a shared workload folder
     output_name = workload_name if workload_name else file_name
 
-    workload_dir = f'../../../inputs/workload/{output_name}'
+    trace_path = input_path(inputs_root, "trace", f"{file_name}.txt")
+    output_path = input_path(inputs_root, "workload", output_name, "llm")
+    workload_dir = os.path.dirname(output_path)
     os.makedirs(workload_dir, exist_ok=True)
 
-    cmd = f'python -m chakra.src.converter.converter LLM ' \
-            f'--input ../../../inputs/trace/{file_name}.txt ' \
-            f'--output ../../../inputs/workload/{output_name}/llm ' \
-            f'--num-npus {num_npus} ' \
-            f'--npu-offset {npu_offset}'
+    cmd = [
+        'python', '-m', 'chakra.src.converter.converter', 'LLM',
+        '--input', trace_path,
+        '--output', output_path,
+        '--num-npus', str(num_npus),
+        '--npu-offset', str(npu_offset),
+    ]
 
     if enable_local_offloading:
-        cmd += ' --local-offloading'
+        cmd.append('--local-offloading')
 
-    logger.debug("Generating graph with command: %s", cmd, extra={"node_id": node_id, "instance_id": instance_id})
+    logger.debug("Generating graph with command: %s", " ".join(cmd), extra={"node_id": node_id, "instance_id": instance_id})
 
-    cmd = cmd.split()
-    subprocess.run(cmd, text=True)    
-    os.chdir(cwd)
+    subprocess.run(cmd, cwd=chakra, text=True)
     return

--- a/serving/core/logger.py
+++ b/serving/core/logger.py
@@ -434,6 +434,8 @@ def print_input_config(args: Any) -> None:
             items.append((label, conv(getattr(args, attr))))
 
     add("cluster_config", "Cluster config", _na)
+    add("run_id", "Run ID", _na)
+    add("inputs_root", "ASTRA-Sim inputs root", _na)
     add("memory_config", "Memory config", _na)
     add("dataset", "Dataset", _na)
     add("num_req", "Num requests")

--- a/serving/core/run_paths.py
+++ b/serving/core/run_paths.py
@@ -1,0 +1,50 @@
+import os
+import re
+from dataclasses import dataclass
+from time import time
+
+
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    run_id: str
+    inputs_root: str
+    network_config: str
+    system_config: str
+    memory_config: str
+
+
+def resolve_run_id(run_id=None):
+    """Return a path-safe run id.
+
+    When omitted, generate a process-unique id so parallel simulator
+    invocations do not share ASTRA-Sim intermediate files.
+    """
+    if run_id is None or str(run_id).strip() == "":
+        return f"run_{int(time() * 1_000_000)}_{os.getpid()}"
+
+    run_id = str(run_id).strip()
+    if run_id in (".", "..") or not _RUN_ID_RE.match(run_id):
+        raise ValueError(
+            "run_id may contain only letters, numbers, '.', '_', and '-'."
+        )
+    return run_id
+
+
+def build_run_paths(astra_sim, run_id, inputs_root=None):
+    if inputs_root is None:
+        inputs_root = os.path.join(astra_sim, "inputs", "runs", run_id)
+    inputs_root = os.path.abspath(inputs_root)
+    return RunPaths(
+        run_id=run_id,
+        inputs_root=os.path.abspath(inputs_root),
+        network_config=os.path.join(inputs_root, "network", "network.yml"),
+        system_config=os.path.join(inputs_root, "system", "system.json"),
+        memory_config=os.path.join(inputs_root, "memory", "memory_expansion.json"),
+    )
+
+
+def input_path(inputs_root, *parts):
+    return os.path.join(os.path.abspath(inputs_root), *parts)

--- a/serving/core/scheduler.py
+++ b/serving/core/scheduler.py
@@ -2,6 +2,7 @@ import bisect
 import pandas as pd
 from time import time
 import csv
+import os
 
 from .request import *
 from .utils import *
@@ -909,7 +910,11 @@ class Scheduler:
         
     # save requests information to an output file
     def save_output(self, output_file, is_append=False):
-        output_file = f'../{output_file}'
+        if not os.path.isabs(output_file):
+            output_file = f'../{output_file}'
+        output_dir = os.path.dirname(output_file)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         mode = 'a' if is_append else 'w'
         with open(output_file, mode=mode, newline='') as file:
             # Initialize the CSV writer

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -10,6 +10,7 @@ from .config_builder import get_device
 from .power_model import PowerModel, total_ring_data
 from .pim_model import PIMModel
 from .logger import get_logger
+from .run_paths import input_path
 import bisect
 from dataclasses import dataclass, field
 
@@ -1449,7 +1450,7 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
                    placement={}, block_mode_on=False, expert_routing_policy="BALANCED",
                    enable_prefix_caching=False, enable_attn_offloading=False, power_model=None, pim_model=None,
                    enable_sub_batch_interleaving=False, fp=16, dtype=None, kv_cache_dtype='auto',
-                   tp_dim=None, ep_dim=None, dp_sum_total_len=0, enable_block_copy=True):
+                   tp_dim=None, ep_dim=None, dp_sum_total_len=0, enable_block_copy=True, inputs_root=None):
 
     model = batch.model
     config = get_config(model)
@@ -1461,7 +1462,12 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
     load_size = batch.load
     evict_size = batch.evict
 
-    output_path = f"inputs/trace/{hardware}/{batch.model}/instance{instance_id}_batch{batch.batch_id}.txt"
+    if inputs_root is None:
+        inputs_root = os.path.join(os.getcwd(), "inputs")
+    output_path = input_path(
+        inputs_root, "trace", hardware, batch.model,
+        f"instance{instance_id}_batch{batch.batch_id}.txt",
+    )
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     # make trace — accept either the Mistral-style ``num_local_experts``
@@ -1560,7 +1566,7 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
 
 
 # generate event for first request arrival
-def generate_event(alarm):
+def generate_event(alarm, inputs_root=None):
 
     # make inputs for text file
     result = []
@@ -1579,7 +1585,10 @@ def generate_event(alarm):
     result.append([layer_name, comp_time, input_loc, input_size, weight_loc, weight_size, output_loc, output_size, comm_type, comm_size, misc])
 
     # write to the text file
-    output_path = f"inputs/trace/event_handler.txt"
+    if inputs_root is None:
+        inputs_root = os.path.join(os.getcwd(), "inputs")
+    output_path = input_path(inputs_root, "trace", "event_handler.txt")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w') as f:
         f.write(f"EVENT\n")
         f.write(f'{len(result)}'+'\n') # length of the text is 1

--- a/serving/core/utils.py
+++ b/serving/core/utils.py
@@ -2,6 +2,8 @@ import os
 from time import time
 import json
 
+from .run_paths import input_path
+
 
 # Formatting string for a trace file's per-layer row. Kept in this
 # module because trace writers live across the codebase and import it
@@ -22,7 +24,7 @@ _FMT = (
 )
 
 
-def get_workload(batch, hardware, instance_id=0, event=False, workload_name=None):
+def get_workload(batch, hardware, instance_id=0, event=False, workload_name=None, inputs_root=None):
     if event:
         file_name = 'event_handler'
     elif workload_name:
@@ -30,8 +32,9 @@ def get_workload(batch, hardware, instance_id=0, event=False, workload_name=None
     else:
         file_name = f'{hardware}/{batch.model}/instance{instance_id}_batch{batch.batch_id}'
 
-    cwd = os.getcwd()
-    return cwd + f"/inputs/workload/{file_name}/llm"
+    if inputs_root is None:
+        inputs_root = os.path.join(os.getcwd(), "inputs")
+    return input_path(inputs_root, "workload", file_name, "llm")
 
 
 def header():


### PR DESCRIPTION
# Add Run-Isolated ASTRA-Sim Inputs for Parallel Serving Runs

## Background

`python -m serving` previously generated ASTRA-Sim intermediate files under shared fixed paths in:

```text
astra-sim/inputs/
```

This made concurrent experiment runs unsafe. If multiple serving processes used the same model, hardware, instance, and batch identifiers, they could write and read the same generated files at the same time.

The most visible failures were trace parser or formatter mismatches, for example:

```text
formatter() takes 11 positional arguments but 13 were given
formatter() missing ... required positional arguments
```

These errors were caused by one process reading a trace file that another process had overwritten or partially rewritten.

---

## Root Cause

Several generated files were shared globally across all serving invocations:

```text
astra-sim/inputs/network/network.yml
astra-sim/inputs/system/system.json
astra-sim/inputs/memory/memory_expansion.json
astra-sim/inputs/trace/...
astra-sim/inputs/workload/...
astra-sim/inputs/trace/event_handler.txt
```

Trace files were especially collision-prone because their paths were based on:

```text
hardware / model / instance_id / batch_id
```

When running multiple experiments with the same cluster/model shape, those fields repeat across processes.

Config files were also fixed singletons. Therefore, even if trace paths were isolated, one ASTRA-Sim process could still read another run's network, system, or memory config.

---

## Solution

This PR adds run-level isolation for generated ASTRA-Sim inputs.

Each `python -m serving` invocation now has a `run_id`, and generated intermediates default to:

```text
astra-sim/inputs/runs/<run_id>/
```

The user can also explicitly override the root with:

```text
--inputs-root <path>
```

The new default layout is:

```text
astra-sim/inputs/runs/<run_id>/
  network/network.yml
  system/system.json
  memory/memory_expansion.json
  trace/...
  workload/...
```

ASTRA-Sim is launched with explicit run-specific paths, so it no longer relies on the old default input locations.

---

## User-Facing Changes

New CLI flags:

```text
--run-id RUN_ID
--inputs-root INPUTS_ROOT
```

`--run-id` is optional. If omitted, serving generates a process-unique id.

`--inputs-root` is optional. If omitted, it defaults to:

```text
astra-sim/inputs/runs/<run_id>
```

`--output` now supports literal `{run_id}` substitution:

```bash
python -m serving \
  --run-id me2_b1_16gpu \
  --output 'outputs/me2/{run_id}.csv'
```

This writes:

```text
outputs/me2/me2_b1_16gpu.csv
```

---

## Implementation Details

### Run Path Helper

Added:

```text
serving/core/run_paths.py
```

This module centralizes:

```text
automatic run id generation
run id validation
run-specific input root construction
helper path joining
```

---

### Config Generation

`serving/core/config_builder.py` now accepts `inputs_root` and writes generated ASTRA-Sim configs into the run-specific directory:

```text
<inputs_root>/network/network.yml
<inputs_root>/system/system.json
<inputs_root>/memory/memory_expansion.json
```

The default `system.json` template is copied into the run-specific path before being modified.

---

### Trace Generation

`serving/core/trace_generator.py` now writes batch traces and event traces under:

```text
<inputs_root>/trace/...
```

This isolates both normal batch traces and:

```text
event_handler.txt
```

---

### Chakra Graph Generation

`serving/core/graph_generator.py` now passes absolute run-specific trace and workload paths to the Chakra converter:

```text
--input  <inputs_root>/trace/...
--output <inputs_root>/workload/.../llm
```

This also avoids relative path issues because the converter runs from the Chakra directory.

---

### ASTRA-Sim Launch

`serving/__main__.py` now passes run-specific paths to ASTRA-Sim:

```text
--workload-configuration=<inputs_root>/workload/.../llm
--system-configuration=<inputs_root>/system/system.json
--network-configuration=<inputs_root>/network/network.yml
--memory-configuration=<inputs_root>/memory/memory_expansion.json
```

---

### DP / EP Workload Sharing

DP group workloads are still shared within the same run, but isolated from other runs.

For example, within one run:

```text
<inputs_root>/workload/.../dp_A_batch0/llm.0.et
<inputs_root>/workload/.../dp_A_batch0/llm.1.et
```

This preserves DP synchronization while preventing cross-experiment collisions.

---

### ns-3 Path Handling

The ns-3 config path is also moved under the run-specific input root.

The generated ns-3 config rewrites output file paths such as:

```text
flow.txt
trace.txt
mix.tr
fct.txt
pfc.txt
qlen.txt
```

under:

```text
<inputs_root>/ns3/output/
```

---

## Final Effect

Multiple `python -m serving` processes can now run concurrently as long as they use different `run_id` values or different `inputs_root` paths.

Concurrent runs no longer overwrite each other's:

```text
network config
system config
memory config
text traces
event handler trace
Chakra workload .et files
```

ASTRA-Sim receives explicit paths to the isolated files, so the backend can run normally without needing to understand `run_id`.

---

## Validation

### Python Compile Check

```bash
python -m compileall serving
```

Result:

```text
Passed.
```

---

### CLI Check

```bash
python -m serving --help
```

Confirmed new flags are present:

```text
--run-id
--inputs-root
```

Confirmed that `--output` documents `{run_id}` support.

---

### Single-Run Smoke Test

```bash
timeout 180s python -m serving \
  --run-id codex_final_seq \
  --cluster-config configs/cluster/single_node_single_instance.json \
  --dataset workloads/example_trace.jsonl \
  --num-reqs 2 \
  --output 'outputs/codex_test/{run_id}.csv' \
  --log-level WARNING
```

Result:

```text
Passed.
```

Confirmed generated files were under:

```text
astra-sim/inputs/runs/codex_final_seq/
```

The generated files included config files, traces, event handler workload, and batch workloads.

---

### Parallel Identical-Run Smoke Test

Started two identical serving runs concurrently:

```bash
python -m serving --run-id codex_final_parallel_a ...
python -m serving --run-id codex_final_parallel_b ...
```

Both completed successfully.

Both wrote separate CSV files and separate run input trees.

No logs contained:

```text
Traceback
ERROR
formatter
KeyboardInterrupt
timed out
```

---

### DP+EP MoE Smoke Test

```bash
timeout 240s python -m serving \
  --run-id codex_final_moe_dp \
  --cluster-config configs/cluster/single_node_moe_dp_ep_instance.json \
  --dataset workloads/example_trace.jsonl \
  --num-reqs 2 \
  --output 'outputs/codex_test/{run_id}.csv' \
  --log-level WARNING
```

Result:

```text
Passed.
```

Confirmed DP shared workloads were generated inside the run root, for example:

```text
astra-sim/inputs/runs/codex_final_moe_dp/workload/.../dp_A_batch0/llm.0.et
astra-sim/inputs/runs/codex_final_moe_dp/workload/.../dp_A_batch0/llm.1.et
```

---

### Auto Run ID Smoke Test

Ran without `--run-id`:

```bash
python -m serving \
  --cluster-config configs/cluster/single_node_single_instance.json \
  --dataset workloads/example_trace.jsonl \
  --num-reqs 1 \
  --output 'outputs/codex_test/auto_{run_id}.csv' \
  --log-level WARNING
```

Result:

```text
Passed.
```

Confirmed the generated run id was used in both:

```text
astra-sim/inputs/runs/<generated_run_id>/
outputs/codex_test/auto_<generated_run_id>.csv
```

---

### Custom Inputs Root Smoke Test

```bash
python -m serving \
  --run-id codex_final_custom_root \
  --inputs-root /app/LLMServingSim/fix_runid/LLMServingSim/outputs/codex_test/custom_inputs_root \
  --cluster-config configs/cluster/single_node_single_instance.json \
  --dataset workloads/example_trace.jsonl \
  --num-reqs 1 \
  --output 'outputs/codex_test/{run_id}.csv' \
  --log-level WARNING
```

Result:

```text
Passed.
```

Confirmed generated ASTRA-Sim inputs were written to the custom root and not to the default path:

```text
astra-sim/inputs/runs/codex_final_custom_root
```

---

### ns-3 Config Rewrite Smoke Test

Verified that `_prepare_ns3_config()` rewrites ns-3 output paths under the run-specific input root.

Also verified that invalid run ids are rejected, for example:

```text
../bad
```
