### PR TITLE
fix: avoid duplicate prefix cache hit accounting

### DIFF
--- a/serving/core/radix_tree.py
+++ b/serving/core/radix_tree.py
@@ -303,13 +303,17 @@ class RadixCache():
             new_prefix_len = self.insert(insert_token_ids)
             # print("[radix_tree: insert()] req_id: {}, insert_len: {}, total_size_after: {}, new_prefix_len: {}".format(req.id, len(insert_token_ids), self.total_size(), new_prefix_len))
 
-            # Track prefix cache stats on first insert (is_init=True, before it's cleared)
+            # Track prefix cache stats once per request, even when chunked prefill
+            # inserts the same request after multiple partial chunks.
             if req.is_init and update:
-                self.total_requested_tokens += req.original_input
-                if self.device == 'NPU':
+                if self.device == 'NPU' and not req._prefix_npu_stats_counted:
+                    self.total_requested_tokens += req.original_input
                     self.total_hit_tokens += req.npu_cache_hit
-                elif self.device == 'CPU' or self.device == 'CXL':
+                    req._prefix_npu_stats_counted = True
+                elif (self.device == 'CPU' or self.device == 'CXL') and not req._prefix_storage_stats_counted:
+                    self.total_requested_tokens += req.original_input
                     self.total_hit_tokens += max(0, req.storage_cache_hit - req.npu_cache_hit)
+                    req._prefix_storage_stats_counted = True
 
             # The prefix indices could be updated, reuse it
             result = self.match_prefix(insert_token_ids)

--- a/serving/core/request.py
+++ b/serving/core/request.py
@@ -34,6 +34,8 @@ class Request:
 
         # For prefix cache lock tracking
         self._prefix_locked = False
+        self._prefix_npu_stats_counted = False
+        self._prefix_storage_stats_counted = False
 
         # For agentic session tracking (informational, does not drive scheduling)
         self.session_id = None


### PR DESCRIPTION
Cause:

Chunked prefill can call cache_unfinished_req() multiple times for the same request before req.is_init is cleared. The old prefix-cache accounting used req.is_init as the only guard, so each partial chunk could repeatedly add the request's full original_input and prefix hit tokens, inflating prefix hit statistics.

Solution:

1. Add per-request flags to track whether NPU and storage prefix-cache stats have already been counted.
2. In radix_tree.py, guard prefix-cache accounting with those flags so each request is counted once per cache tier.

Validation:

I ran the same simulation command on both the original version and the patched version. The original version shows inflated prefix-cache hit statistics, while the patched version keeps the statistics counted once per request. Except for the input/output paths and log/output filenames, all other command arguments were kept unchanged.

Please refer to the attached logs for details:

* `[before_fix.log](https://github.com/user-attachments/files/29181148/before_fix.log)`
* `[after_fix.log](https://github.com/user-attachments/files/29181152/after_fix.log)`

Command used for both runs:

```bash
python -m serving --cluster-config 'configs/cluster/single_node_pd_instance.json' --dtype bfloat16 --dataset 'workloads/sharegpt-llama-3.1-8b-300-sps10.jsonl' --output 'outputs/me_cache_hit.csv' --run-id "test11" --log-interval 0.5 --log-level WARNING > before_fix.log 2>&1
```
