### PR TITLE
Fix multi-tier prefix cache load size accounting

### DIFF
--- a/serving/core/scheduler.py
+++ b/serving/core/scheduler.py
@@ -542,8 +542,8 @@ class Scheduler:
                         break
 
                 # Load prefix cache from storage if needed
-                if req.is_prefill() and req.storage_cache_hit > req.prefix_cache_hit:
-                    prefix_load_size += (req.storage_cache_hit - req.prefix_cache_hit) * self.memory.get_kv(1)
+                if req.is_prefill() and req.storage_cache_hit > req.npu_cache_hit:
+                    prefix_load_size += (req.storage_cache_hit - req.npu_cache_hit) * self.memory.get_kv(1)
 
                 # Handle evicted requests
                 if req.evict:


### PR DESCRIPTION
## Summary

Fixes the storage-to-NPU prefix cache load size accounting in `scheduler.py`.

The check used:

```python
if req.is_prefill() and req.storage_cache_hit > req.prefix_cache_hit:
    prefix_load_size += (req.storage_cache_hit - req.prefix_cache_hit) * self.memory.get_kv(1)
```

But `prefix_cache_hit = max(npu_cache_hit, storage_cache_hit)`, so
`storage_cache_hit > prefix_cache_hit` can never be true — the branch was dead
code and `prefix_load_size` was never accumulated from the storage tier.

The fix compares against `npu_cache_hit`, so the KV bytes that exist in the
storage tier but not on the NPU (`storage_cache_hit - npu_cache_hit`) are
charged as a load:

```python
if req.is_prefill() and req.storage_cache_hit > req.npu_cache_hit:
    prefix_load_size += (req.storage_cache_hit - req.npu_cache_hit) * self.memory.get_kv(1)
```

This mirrors the storage-tier hit accounting in `radix_tree.py`, which uses
`max(0, storage_cache_hit - npu_cache_hit)`.

## Credit

Thanks to @AlishKanani for reporting the issue and pinpointing the fix.

Fixes #46