### PR TITLE
fix: clean up intermediate ASTRA-Sim inputs to save storage

### DIFF
--- a/docs/docs/reference/cli-flags.md
+++ b/docs/docs/reference/cli-flags.md
@@ -70,12 +70,15 @@ matching runtime knobs per `instances[i]`; see
 
 Each invocation writes ASTRA-Sim intermediates under a run-specific input
 root so parallel simulations do not overwrite each other's generated
-configs, traces, or Chakra workloads.
+configs, traces, or Chakra workloads. Generated text traces are removed
+after Chakra conversion by default, and the run-specific input root is
+removed after a successful simulation by default.
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--run-id` | string | auto-generated | Path-safe id for this simulation run. Used in `astra-sim/inputs/runs/<run-id>` and the `{run_id}` output placeholder |
 | `--inputs-root` | path | `astra-sim/inputs/runs/<run-id>` | Override the generated ASTRA-Sim input root, for example to place intermediates on local SSD or tmpfs |
+| `--cleanup-inputs` / `--no-cleanup-inputs` | bool | `true` | Remove generated trace files after Chakra conversion and remove the generated run directory after a successful simulation. Use `--no-cleanup-inputs` to preserve traces, Chakra workloads, and input configs for debugging |
 
 ## Logging
 

--- a/docs/docs/reference/trace-format.md
+++ b/docs/docs/reference/trace-format.md
@@ -20,7 +20,8 @@ astra-sim/inputs/runs/<run_id>/trace/<hardware>/<model>/instance_<i>_batch_<b>.t
 ```
 
 One file per (instance × batch), under the run-specific ASTRA-Sim input
-root. Regenerated every iteration.
+root. Regenerated every iteration and removed after Chakra conversion by
+default. Use `--no-cleanup-inputs` to preserve generated traces.
 
 ## File structure
 

--- a/docs/docs/simulator/request-lifecycle.md
+++ b/docs/docs/simulator/request-lifecycle.md
@@ -162,6 +162,9 @@ profile DB:
 
 The output is a tab-separated text trace at
 `astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
+The text trace is an intermediate input to the Chakra converter and is
+removed after the `.et` graph is generated unless `--no-cleanup-inputs`
+is set.
 Full mechanics on **[Trace generation](./trace-generation)**.
 
 ## Stage 7, Converted to Chakra graph
@@ -169,6 +172,9 @@ Full mechanics on **[Trace generation](./trace-generation)**.
 `graph_generator.generate_graph` shells out to Chakra's text→protobuf
 converter, producing
 `astra-sim/inputs/runs/<run_id>/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
+Chakra workloads remain available while ASTRA-Sim consumes them; the
+run directory is removed after a successful simulation unless
+`--no-cleanup-inputs` is set.
 
 The Chakra converter creates:
 

--- a/serving/README.md
+++ b/serving/README.md
@@ -166,6 +166,10 @@ matching `sequence:` rather than editing this file.
 Parses the user-provided cluster config JSON from `configs/cluster/` and generates the
 ASTRA-Sim input files under `astra-sim/inputs/runs/<run_id>/`: `network/network.yml`,
 `memory/memory_expansion.json`, and `system/system.json`.
+Per-iteration text traces are removed after Chakra conversion by default, and the
+generated run directory is removed after a successful simulation by default. Use
+`--no-cleanup-inputs` to preserve traces, Chakra workloads, and input configs for
+debugging.
 For DP groups, generates a 2D network topology `[tp_size, dp_group_size]` and sets
 `system.json` collective implementations to match the number of topology dimensions.
 Computes `tp_dim`/`ep_dim` per instance for `involved_dim` scoping.

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import argparse
 import json
+import shutil
 from time import time
 from collections import defaultdict
 
@@ -80,6 +81,22 @@ def _resolve_output_file(path, run_id):
     if path is None:
         return None
     return path.replace("{run_id}", run_id)
+
+
+def _cleanup_inputs_root(run_paths, logger):
+    """Remove generated ASTRA-Sim inputs after a completed simulation."""
+    runs_root = os.path.abspath(os.path.join("inputs", "runs"))
+    inputs_root = os.path.abspath(run_paths.inputs_root)
+    if inputs_root in (os.path.abspath("inputs"), runs_root):
+        raise RuntimeError(f"Refusing to remove broad inputs root: {inputs_root}")
+    if not inputs_root.startswith(runs_root + os.sep):
+        logger.warning(
+            "Skipping ASTRA-Sim inputs cleanup because inputs_root is outside %s: %s",
+            runs_root, inputs_root,
+        )
+        return
+    shutil.rmtree(inputs_root, ignore_errors=True)
+    logger.info("Removed ASTRA-Sim inputs root: %s", inputs_root)
 
 
 def _prepare_ns3_config(astra_sim, run_paths):
@@ -256,6 +273,10 @@ def main():
     parser.add_argument('--inputs-root', type=str, default=None,
                         help='override the root directory for generated ASTRA-Sim inputs. Defaults to '
                         'astra-sim/inputs/runs/<run-id>')
+    parser.add_argument('--cleanup-inputs', action=argparse.BooleanOptionalAction, default=True,
+                        help='remove generated ASTRA-Sim inputs under astra-sim/inputs/runs/<run-id> '
+                        'after a successful simulation (default: enabled). Use --no-cleanup-inputs '
+                        'to preserve generated trace files, Chakra workloads, and input configs for debugging')
     parser.add_argument('--skip-prefill', action='store_true', default=False,
                         help='skip the prefill phase, running decode only')
     parser.add_argument('--num-reqs', type=int, default=0,
@@ -493,7 +514,8 @@ def main():
         event_time = INTERVAL
     generate_event(int(event_time), inputs_root=run_paths.inputs_root)
     # Make Chakra Grapth
-    generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root)
+    generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root,
+                   cleanup_trace=args.cleanup_inputs)
     # set first workload file
     workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
@@ -640,7 +662,8 @@ def main():
                                        inst_id, inst2npu_mapping[inst_id],
                                        inst_cfg["enable_local_offloading"],
                                        workload_name=dp_workload_name,
-                                       inputs_root=run_paths.inputs_root)
+                                       inputs_root=run_paths.inputs_root,
+                                       cleanup_trace=args.cleanup_inputs)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                     workload_name=dp_workload_name,
@@ -706,7 +729,8 @@ def main():
                                            inst_id, inst2npu_mapping[inst_id],
                                            inst_cfg["enable_local_offloading"],
                                            workload_name=dp_workload_name,
-                                           inputs_root=run_paths.inputs_root)
+                                           inputs_root=run_paths.inputs_root,
+                                           cleanup_trace=args.cleanup_inputs)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                         workload_name=dp_workload_name,
@@ -740,7 +764,8 @@ def main():
                     generate_graph(new_req, instance["hardware"], instance["num_npus"], node_id,
                                    instance_id, inst2npu_mapping[instance_id],
                                    inst_cfg["enable_local_offloading"],
-                                   inputs_root=run_paths.inputs_root)
+                                   inputs_root=run_paths.inputs_root,
+                                   cleanup_trace=args.cleanup_inputs)
                     workload = get_workload(new_req, instance["hardware"], instance_id,
                                             inputs_root=run_paths.inputs_root)
                     controller.write_flush(p, workload)
@@ -1005,6 +1030,9 @@ def main():
         print(f"Saving each request's information to output file: {output_file}")
         for i in range(num_instances):
             schedulers[i].save_output(output_file, is_append=False if i == 0 else True)
+
+    if args.cleanup_inputs:
+        _cleanup_inputs_root(run_paths, logger)
     
 
 if __name__ == "__main__": 

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -7,7 +7,7 @@ from .run_paths import input_path
 
 logger = get_logger("GraphGenerator")
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None):
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True):
 
     cwd = os.getcwd()
     chakra = os.path.join(cwd, "extern/graph_frontend/chakra")
@@ -40,5 +40,10 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
 
     logger.debug("Generating graph with command: %s", " ".join(cmd), extra={"node_id": node_id, "instance_id": instance_id})
 
-    subprocess.run(cmd, cwd=chakra, text=True)
+    subprocess.run(cmd, cwd=chakra, text=True, check=True)
+    if cleanup_trace:
+        try:
+            os.remove(trace_path)
+        except FileNotFoundError:
+            pass
     return


### PR DESCRIPTION
## Summary

  This PR adds cleanup for generated ASTRA-Sim intermediate inputs created during `python -m serving` runs.

  Previously, each simulation wrote a run-specific input tree under:

  astra-sim/inputs/runs/<run_id>/

  That tree accumulated per-run configuration files, generated text traces, and Chakra workload protobufs. Long simulations can produce one trace/workload bundle per scheduled batch or
  iteration, so the trace/ and workload/ subdirectories can grow quickly and create unnecessary storage pressure.

  This PR makes intermediate cleanup the default behavior while preserving a debug escape hatch.

  ## Problem
<img width="630" height="467" alt="image" src="https://github.com/user-attachments/assets/3825eca7-be87-4080-89d0-14405dc29d80" />
  LLMServingSim drives ASTRA-Sim through generated input files:

  1. The Python scheduler creates a batch.
  2. trace_generator.py writes a per-batch text trace under astra-sim/inputs/runs/<run_id>/trace/....
  3. graph_generator.py invokes the Chakra converter to turn that trace into .et workload files under astra-sim/inputs/runs/<run_id>/workload/....
  4. The Python controller sends the workload path to the ASTRA-Sim subprocess.
  5. ASTRA-Sim reads the .et files and returns the simulated cycle count.

  Before this change, these generated files were left on disk after use. Since continuous batching, chunked prefill, decode iterations, multi-instance runs, and DP/EP synchronization can all
  generate many batches, the number of intermediate files grows with simulation length. Repeated runs also leave old run_id directories behind.

  The text trace files are only needed until Chakra conversion succeeds, but they were retained for the full run. The workload .et files must remain available while ASTRA-Sim may still consume
  them, but they do not need to survive after a successful simulation unless the user is debugging.



  ## Solution

  This PR introduces default cleanup behavior:

  - Remove each generated .txt trace after Chakra conversion succeeds.
  - Remove the generated astra-sim/inputs/runs/<run_id> directory after a successful simulation.
  - Add --no-cleanup-inputs to preserve generated traces, Chakra workloads, and input configs for debugging.
  - Keep cleanup scoped to the default astra-sim/inputs/runs/<run_id> tree. If --inputs-root points outside astra-sim/inputs/runs, cleanup is skipped to avoid deleting user-managed paths.

  The Chakra conversion call now uses check=True, so failed conversions surface immediately and the input trace is not removed on converter failure.

  ## User-visible behavior

  Default behavior:

  python -m serving ...

  Generated text traces are removed after conversion, and the run directory is removed after a successful simulation.

  Debug behavior:

  python -m serving ... --no-cleanup-inputs

  The full generated input tree is preserved, including:

  astra-sim/inputs/runs/<run_id>/trace/
  astra-sim/inputs/runs/<run_id>/workload/
  astra-sim/inputs/runs/<run_id>/network/
  astra-sim/inputs/runs/<run_id>/system/
  astra-sim/inputs/runs/<run_id>/memory/

  ## Files changed

  - serving/core/graph_generator.py
      - Deletes converted text traces after successful Chakra conversion.
      - Uses subprocess.run(..., check=True) for conversion failures.

  - serving/__main__.py
      - Adds --cleanup-inputs / --no-cleanup-inputs.
      - Defaults cleanup to enabled.
      - Passes the cleanup setting into all generate_graph() calls.
      - Removes the generated run directory after successful simulation completion.

  - docs/docs/reference/cli-flags.md
      - Documents the new cleanup behavior and debug flag.

  - docs/docs/simulator/request-lifecycle.md
      - Documents when traces and workloads are generated and cleaned up.

  - docs/docs/reference/trace-format.md
      - Notes that generated trace files are removed by default after Chakra conversion.

  - serving/README.md
      - Updates module-level notes about generated ASTRA-Sim inputs.

  ## Validation

  Ran:

  python -m py_compile serving/core/graph_generator.py serving/__main__.py
  git diff --check -- serving/__main__.py serving/core/graph_generator.py docs/docs/reference/cli-flags.md docs/docs/simulator/request-lifecycle.md docs/docs/reference/trace-format.md serving/
  README.md

  Both checks passed.

  Docusaurus build was not run because the current environment does not have node or pnpm installed.

  ## Future work

  A future improvement should move .et cleanup closer to ASTRA-Sim itself.

  Today, serving-side Python can safely delete text traces after conversion and clean the whole run directory after simulation completion. It cannot safely delete .et workload files immediately
  after submitting their path, because ASTRA-Sim may still hold the path in pending_workloads or may still be reading the file through ETFeeder.

  A robust next step is to modify the ASTRA-Sim side so that once each .et file is successfully opened by ETFeeder, ASTRA-Sim unlinks it from the filesystem. On POSIX systems, this would remove
  the directory entry immediately while allowing the already-open file descriptor to remain readable until ASTRA-Sim finishes consuming it. That would allow workload files to disappear during
  the run instead of waiting for the final run-directory cleanup.