### PR TITLE
Fix: args shadowing in serving/__main__.py

### DIFF
--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -519,14 +519,14 @@ def main():
     # set first workload file
     workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
-    args = [binary, "--workload-configuration="+workload, "--system-configuration="+system, "--network-configuration="+network, "--memory-configuration="+memory]
+    astra_args = [binary, "--workload-configuration="+workload, "--system-configuration="+system, "--network-configuration="+network, "--memory-configuration="+memory]
     if start_npu_ids != "":
-        args.append("--start-npu-ids="+start_npu_ids)
+        astra_args.append("--start-npu-ids="+start_npu_ids)
     if end_npu_ids != "":
-        args.append("--end-npu-ids="+end_npu_ids)
+        astra_args.append("--end-npu-ids="+end_npu_ids)
     if network_backend == 'ns3':
-        args.append("--logical-topology-configuration="+astra_sim+"/inputs/logical_topology/logical_8nodes_1D.json")
-    p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        astra_args.append("--logical-topology-configuration="+astra_sim+"/inputs/logical_topology/logical_8nodes_1D.json")
+    p = subprocess.Popen(astra_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
     # DP group synchronization: defer trace generation until all members have scheduled
     # dp_groups maps dp_group_name -> list of instance_ids


### PR DESCRIPTION
 Fix `args` shadowing in serving main loop

  The ASTRA-Sim subprocess command list in `serving/__main__.py` reused the
  name `args`, which overwrote the argparse namespace created earlier in `main()`.

  That caused `args.cleanup_inputs` to fail at runtime with:
  `AttributeError: 'list' object has no attribute 'cleanup_inputs'`

  Fix:
  - Rename the subprocess command list to `astra_args`
  - Keep the argparse namespace intact for later cleanup logic
  - Preserve the `--cleanup-inputs` / `--no-cleanup-inputs` behavior

  Validation:
  - `python -m py_compile serving/__main__.py serving/core/graph_generator.py`
  - `python -m serving \
  --cluster-config 'configs/cluster/single_node_single_instance.json' \
  --dtype bfloat16 --block-size 16 \
  --dataset 'workloads/example_trace.jsonl' \
  --output 'outputs/example_single_run.csv' \
  --log-interval 1.0`

  Sorry for last PR, I did not run full validation after the previous small change, so this
  name shadowing bug was not caught earlier.