### PR TITLE
Fix: simulator docs pagination

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -71,7 +71,6 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Simulator',
-      link: {type: 'doc', id: 'simulator/architecture'},
       items: [
         'simulator/architecture',
         'simulator/request-lifecycle',


### PR DESCRIPTION
## Summary

Before this change, the `Next` link at the bottom of the `Architecture overview` docs page currently links back to `Architecture overview` itself.

This PR fixes the sidebar config so the next page is `Request lifecycle`.

<img width="1495" height="489" alt="screenshot" src="https://github.com/user-attachments/assets/c8e2b6f3-d51a-4e12-b4a8-8cc5428363e8" />

## Validation

Ran these command locally and verify the link is fixed.

- `node scripts/sync-changelog.mjs`
- `./node_modules/.bin/docusaurus build`

<img width="1204" height="419" alt="image" src="https://github.com/user-attachments/assets/a1e53926-1455-4c14-b597-f503c12b393c" />
