### PR TITLE
Fix stale --dtype float16 in run.sh and docs examples

### DIFF
--- a/docs/docs/examples/advanced/power-modeling.md
+++ b/docs/docs/examples/advanced/power-modeling.md
@@ -76,7 +76,7 @@ For the field-by-field schema (`base_node_power`, `idle_power`,
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_power_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/power_run.csv' \
   --log-interval 1.0

--- a/docs/docs/examples/advanced/sub-batch-interleaving.md
+++ b/docs/docs/examples/advanced/sub-batch-interleaving.md
@@ -39,7 +39,7 @@ are needed; sub-batch interleaving is a runtime CLI flag.
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_pim_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --enable-attn-offloading \
   --enable-sub-batch-interleaving \
   --dataset 'workloads/example_trace.jsonl' \

--- a/docs/docs/examples/disaggregated/multi-instance.mdx
+++ b/docs/docs/examples/disaggregated/multi-instance.mdx
@@ -64,7 +64,7 @@ The two pieces:
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_multi_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/multi_instance_run.csv' \
   --request-routing-policy LOAD \

--- a/docs/docs/examples/disaggregated/pim-attention-offload.mdx
+++ b/docs/docs/examples/disaggregated/pim-attention-offload.mdx
@@ -74,7 +74,7 @@ The PIM hookup:
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_pim_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --enable-attn-offloading \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/pim_offload_run.csv' \

--- a/docs/docs/examples/disaggregated/prefill-decode-split.mdx
+++ b/docs/docs/examples/disaggregated/prefill-decode-split.mdx
@@ -73,7 +73,7 @@ token. The KV-cache transfer cost is modeled through the inter-link.
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_pd_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/pd_split_run.csv' \
   --log-interval 1.0

--- a/docs/docs/examples/memory-tiers/cxl-memory.mdx
+++ b/docs/docs/examples/memory-tiers/cxl-memory.mdx
@@ -113,7 +113,7 @@ devices in roughly equal chunks, while keeping KV cache on NPU.
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_cxl_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/cxl_run.csv' \
   --log-interval 1.0

--- a/docs/docs/examples/memory-tiers/prefix-caching.mdx
+++ b/docs/docs/examples/memory-tiers/prefix-caching.mdx
@@ -69,7 +69,7 @@ can grow.
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_multi_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/prefix_default_run.csv'
 ```
@@ -83,7 +83,7 @@ that prefixes-into a cached block on instance B, no reuse happens.
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_multi_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --enable-prefix-caching --enable-prefix-sharing --prefix-storage CPU \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/prefix_cpu_pool_run.csv'

--- a/docs/docs/examples/parallelism/pipeline-parallel.md
+++ b/docs/docs/examples/parallelism/pipeline-parallel.md
@@ -66,7 +66,7 @@ The two fields that matter:
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_pp_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/pp2_run.csv' \
   --log-interval 1.0

--- a/docs/docs/getting-started/installation/simulator.mdx
+++ b/docs/docs/getting-started/installation/simulator.mdx
@@ -93,7 +93,7 @@ Run the bundled smoke test from inside the simulator container:
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_single_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/example_single_run.csv' \
   --log-interval 1.0

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ inside the simulator container at `/app/LLMServingSim`.
 ```bash
 python -m serving \
   --cluster-config 'configs/cluster/single_node_single_instance.json' \
-  --dtype float16 --block-size 16 \
+  --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/example_single_run.csv' \
   --log-interval 1.0

--- a/serving/run.sh
+++ b/serving/run.sh
@@ -2,57 +2,57 @@
 
 # Single instance example (prefix caching in xPU memory is default now)
 python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
-    --dtype float16 --block-size 16 \
+    --dtype bfloat16 --block-size 16 \
     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_single_run.csv' \
     --num-req 10
 
 # Multi instance example
 # python -m serving --cluster-config 'configs/cluster/single_node_multi_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_multi_run.csv' \
 #     --num-req 10
 
 # # PD example
 # python -m serving --cluster-config 'configs/cluster/single_node_pd_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pd_run.csv' \
 #     --num-req 10
 
 # # CXL example
 # python -m serving --cluster-config 'configs/cluster/single_node_cxl_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_cxl_run.csv' \
 #     --num-req 10
 
 # # Prefix cache with CPU Prefix Cache Pool example (Single Node)
 # python -m serving --cluster-config 'configs/cluster/single_node_multi_instance.json' \
-#      --dtype float16 --block-size 16 \
+#      --dtype bfloat16 --block-size 16 \
 #     --enable-prefix-caching --enable-prefix-sharing --prefix-storage CPU \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_prefix_cpu_mem_pool_run.csv' \
 #     --num-req 10
 
 # # Prefix cache with CPU Prefix Cache Pool example (Dual Node)
 # python -m serving --cluster-config 'configs/cluster/dual_node_multi_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --enable-prefix-caching --enable-prefix-sharing --prefix-storage CPU \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_dual_prefix_cpu_mem_pool_run.csv' \
 #     --num-req 10
 
 # # Power model example
 # python -m serving --cluster-config 'configs/cluster/single_node_power_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_power_run.csv' \
 #     --num-req 10 --log-interval 0.1
 
 # # PIM example
 # python -m serving --cluster-config 'configs/cluster/single_node_pim_instance.json' \
-#     --dtype float16 --block-size 16 --enable-attn-offloading \
+#     --dtype bfloat16 --block-size 16 --enable-attn-offloading \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pim_run.csv' \
 #     --num-req 10 --log-level WARNING
 
 # # Sub-batch interleaving example
 # python -m serving --cluster-config 'configs/cluster/single_node_pim_instance.json' \
-#     --dtype float16 --block-size 16 --enable-attn-offloading --enable-sub-batch-interleaving \
+#     --dtype bfloat16 --block-size 16 --enable-attn-offloading --enable-sub-batch-interleaving \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pim_sub_batch_run.csv' \
 #     --num-req 10 --log-level WARNING
 
@@ -60,13 +60,13 @@ python -m serving --cluster-config 'configs/cluster/single_node_single_instance.
 
 # MoE example
 # python -m serving --cluster-config 'configs/cluster/single_node_moe_single_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_moe_run.csv' \
 #     --num-req 10
 
 # MoE DP+EP with agentic session example (SWE-bench)
 # python -m serving --cluster-config 'configs/cluster/single_node_moe_dp_ep_instance.json' \
-#     --dtype float16 --block-size 16 \
+#     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl' --output 'outputs/example_moe_dp_ep_run.csv' \
 #     --num-req 1 # session count in agentic workload
 
@@ -78,13 +78,13 @@ python -m serving --cluster-config 'configs/cluster/single_node_single_instance.
 
 # Prefix caching example (disabled: prefix caching in xPU memory is default now)
 # python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
-#     --dtype float16 --block-size 16 --enable-prefix-caching \
+#     --dtype bfloat16 --block-size 16 --enable-prefix-caching \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_prefix_run.csv' \
 #     --num-req 10
 
 # NS-3 example
 # Note: NS-3 integration is currently a work in progress. The following command is a placeholder and may not work until the NS-3 integration is complete.
 # python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
-#     --dtype float16 --block-size 16 --network-backend 'ns3' \
+#     --dtype bfloat16 --block-size 16 --network-backend 'ns3' \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_ns3_run.csv' \
 #     --num-req 10 


### PR DESCRIPTION
## What this changes

Update the `--dtype float16` examples in `serving/run.sh` and the docs site to `--dtype bfloat16` (23 occurrences across 11 files).

## Why

Since v1.1.0 (3012eb1) `--dtype` selects the profiler variant folder under `perf/<hw>/<model>/<variant>/`. The bundled profile data only ships `bf16/`, so every documented example fails with:
```
FileNotFoundError: Profile variant folder not found:
  ../profiler/perf/RTXPRO6000/meta-llama/Llama-3.1-8B/fp16
```

## Validation

```bash
$ python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
  --dtype bfloat16 --block-size 16 \
  --dataset 'workloads/example_trace.jsonl' \
  --output 'outputs/example_single_run.csv' --num-req 10
...
Saving each request information to output file: outputs/example_single_run.csv
# 10/10 requests completed, 6.01 req/s, mean TTFT 15.73 ms, mean TPOT 11.15 ms
# outputs/example_single_run.csv matches the committed reference byte-for-byte

$ cd docs && pnpm build
...
[SUCCESS] Generated static files in "build".
```

## Notes

`--dtype float16` remains a valid flag; it just requires profiling with `DTYPE="float16"` to produce an `fp16/` variant. Only the examples were out of sync with the shipped data.
