### PR TITLE
Realign the docs with the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,8 @@ are not part of the main branch's tree.
 ### Key data flow
 
 ```
-profile.csv (profiled latencies)
-    ↓ _load_perf_db() + _lookup_latency_ns()
+profiler/perf/<hw>/<model>/<variant>/tp<N>/*.csv (profiled latencies)
+    ↓ _load_perf_db() + _lookup_{dense,per_sequence,attention,moe}()
 trace_generator.py → text trace file
     ↓ Chakra converter
 graph_generator.py → .et protobuf file
@@ -173,9 +173,14 @@ decode batch has non-uniform kv lengths. The uniform attention grid can't see
 that (every shot uses a single kv_decode value), so `skew.py` runs a second
 sweep on bimodal batches and measures three latencies per case — `t_mean`
 (all decodes at the batch mean), `t_max` (all at the max), and `t_skew` (the
-actual bimodal mix). The normalised alpha ∈ [0, 1],
-`alpha = (t_skew − t_mean) / (t_max − t_mean)`, tells the simulator how far
-along the mean→max line a skewed batch lands.
+actual bimodal mix). The alpha
+`alpha = (t_skew − t_mean) / (t_max − t_mean)` tells the simulator how far
+along the mean→max line a skewed batch lands. It is **not** clamped to
+[0, 1], in the fit or in `_skew_alpha`: measured p50 is 0.07–0.13, but
+14–20% of rows are negative (endpoint gap inside measurement noise) and
+2–5% exceed 1 (a skewed mix genuinely costing more than uniform-max,
+which tile padding and SM imbalance do not bound). Rows with
+`t_max <= t_mean` are recorded `nan` and dropped.
 
 - **Sweep structure**: Tier 1 is a factorial over `(n, ratio, pc, kp, kvs)`
   at `_SKEW_REP = 4.0`; Tier 2 adds a skew-axis sweep at a handful of anchor
@@ -283,7 +288,7 @@ sampler_291  25933        LOCAL        2565120       LOCAL         0            
   transformer-block starts using vLLM's `get_pp_indices` rule — blocks split
   evenly, remainder to the stages *before* the last, which also carries
   `lm_head`
-- `comp_time`: latency in nanoseconds (from profile.csv, converted at load time)
+- `comp_time`: latency in nanoseconds (from the per-category CSVs, whose `time_us` is converted at load time)
 - `input_loc`/`weight_loc`/`output_loc`: `LOCAL` (NPU), `REMOTE:{node_id}` (CPU), `CXL:{id}`
 - `comm_type`: `NONE`, `ALLREDUCE`, `ALLTOALL`, or with dimension scoping `ALLREDUCE:1,0`, `ALLTOALL:0,1`
   (the `:dim0,dim1` suffix maps to ASTRA-Sim's `involved_dim` BoolList for multi-dimensional topologies)

--- a/bench/README.md
+++ b/bench/README.md
@@ -54,6 +54,30 @@ python -m bench run \
     --dtype bfloat16 --kv-cache-dtype auto
 ```
 
+All 15 flags:
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--model` | required | HF id, passed verbatim to `vllm.AsyncLLM` |
+| `--dataset` | required | LLMServingSim-format JSONL |
+| `--output-dir` | required | run output root |
+| `--tensor-parallel-size` | `1` | vLLM `tensor_parallel_size` |
+| `--data-parallel-size` | `1` | vLLM `data_parallel_size` |
+| `--enable-expert-parallel` | off | vLLM `enable_expert_parallel`, MoE only |
+| `--max-num-seqs` | `128` | vLLM `max_num_seqs` |
+| `--max-num-batched-tokens` | `2048` | vLLM `max_num_batched_tokens` |
+| `--max-model-len` | model max | vLLM `max_model_len` |
+| `--dtype` | `bfloat16` | note: not inferred from the model config, unlike `python -m serving` |
+| `--kv-cache-dtype` | `auto` | vLLM `kv_cache_dtype` |
+| `--seed` | `42` | sampling seed |
+| `--tick-seconds` | `1.0` | `timeseries.csv` row spacing; the simulator's `--log-interval` |
+| `--num-reqs` | `0` | cap on requests from the dataset, `0` = all |
+| `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` |
+
+There is no `--block-size`: vLLM picks the KV block size itself and records
+what it chose in `meta.json` under `kv_cache.block_size`. Pass that value to
+the simulator as `--block-size` to line the two up.
+
 `bench validate` — compare a finished bench run against simulator output
 
 Loads the bench artifacts plus the simulator's `sim.csv` / `sim.log`
@@ -68,6 +92,20 @@ summary into a subdirectory of the bench run.
     outputs/<sim-run>/sim.log \
     [prefix]
 ```
+
+`validate.sh` sets `--output-subdir`, `--title` and `--log-level` from the
+`OUTPUT_SUBDIR` / `TITLE` / `LOG_LEVEL` environment variables. The module
+itself takes all seven directly:
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--bench-dir` | required | a finished `bench run` output directory |
+| `--sim-csv` | required | simulator `--output` CSV |
+| `--sim-log` | required | simulator stdout, parsed for per-tick running / waiting |
+| `--output-subdir` | `validation` | subdirectory under `--bench-dir` |
+| `--prefix` | `""` | filename prefix for plots and summary |
+| `--title` | `vLLM vs LLMServingSim` | plot title suffix |
+| `--log-level` | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` |
 
 ## Output schema (one bench run)
 

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # .../scripts
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"   # .../bench
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 

--- a/configs/cluster/README.md
+++ b/configs/cluster/README.md
@@ -61,8 +61,8 @@ Pass a config file to `python -m serving` via `--cluster-config configs/cluster/
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `model_name` | String | Yes | HuggingFace model identifier (must match `configs/model/`) |
-| `hardware` | String | Yes | Hardware name matching `profiler/perf_models/{hardware}/` |
-| `npu_mem` | Object | Yes | NPU memory config (`mem_size` in GB, `mem_bw` in GB/s, `mem_latency` in ns) |
+| `hardware` | String | Yes | Hardware name matching `profiler/perf/{hardware}/` |
+| `npu_mem` | Object | Yes | NPU memory config (`mem_size` in GB, `mem_bw` in GB/s, `mem_latency` in ns; optional `mem_util`, see below) |
 | `pd_type` | String/null | Yes | `"prefill"`, `"decode"`, or `null` for combined |
 | `num_npus` | Integer | * | Total GPUs for this instance (inferred from `tp_size * pp_size` if omitted) |
 | `tp_size` | Integer | * | Tensor parallel degree (inferred from `num_npus // pp_size` if omitted) |
@@ -70,7 +70,7 @@ Pass a config file to `python -m serving` via `--cluster-config configs/cluster/
 | `ep_size` | Integer | No | Expert parallel degree (default: `tp_size` for MoE, 1 for dense) |
 | `dp_group` | String/null | No | DP group ID. Instances with the same string share experts via cross-instance ALLTOALL |
 | `max_num_seqs` | Integer | No | Per-instance override for `--max-num-seqs` (`0` = unlimited) |
-| `max_num_batched_tokens` | Integer | No | Per-instance override for `--max-num-batched-tokens` (`0` = unlimited) |
+| `max_num_batched_tokens` | Integer | No | Per-instance override for `--max-num-batched-tokens` (`0` = capped at the model's `max_position_embeddings`, see below) |
 | `long_prefill_token_threshold` | Integer | No | Per-instance override for `--long-prefill-token-threshold` |
 | `block_size` | Integer | No | Per-instance override for `--block-size` |
 | `dtype` | String | No | Per-instance override for `--dtype` |
@@ -88,7 +88,7 @@ Pass a config file to `python -m serving` via `--cluster-config configs/cluster/
 
 ### Per-instance runtime overrides
 
-The 13 runtime fields listed above (`max_num_seqs`, `max_num_batched_tokens`, etc.) support **per-instance overrides** in the cluster config. This enables heterogeneous deployments where different instances in the same cluster use different scheduler limits.
+The 14 runtime fields listed above (`max_num_seqs`, `max_num_batched_tokens`, etc.) support **per-instance overrides** in the cluster config. This enables heterogeneous deployments where different instances in the same cluster use different scheduler limits.
 
 **Precedence rule:**
 ```
@@ -98,35 +98,74 @@ per-instance value (from cluster config) > global CLI value (from --flag)
 For each field, the runtime reads `instance.get("<field>", args.<field>)` — if the field is present in the cluster config, it takes precedence; otherwise the global CLI value is used.
 
 **Unlimited semantics:**
-Setting a numeric field to `0` means "unlimited" (via the `_runtime_limit` helper). For example:
+Setting either batching limit to `0` maps it to infinity via the `_runtime_limit` helper:
 - `max_num_seqs: 0` → no limit on concurrent sequences
-- `max_num_batched_tokens: 0` → no limit on batched tokens
+- `max_num_batched_tokens: 0` → **not** actually unbounded. The scheduler then takes
+  `min(max_num_batched_tokens, max_position_embeddings)`, so the effective budget is the
+  model's context length from its `configs/model/` entry (4096 on
+  `microsoft/Phi-mini-MoE-instruct`, not infinity).
+
+`long_prefill_token_threshold: 0` means *disabled* (no per-request cap), matching the CLI
+flag — it is not an "unlimited" sentinel.
+
+**`dtype` has a third fallback level:**
+```
+instances[i].dtype  >  --dtype  >  model config torch_dtype  >  bfloat16
+```
+The resolved value picks the profile variant folder, so
+`profiler/perf/{hardware}/{model}/{variant}/tp{N}/` must exist for it.
+
+**`npu_mem.mem_util` is the one nested override.** The other 13 are plain instance keys;
+`mem_util` lives inside `npu_mem` because its only job is to scale `mem_size`. It must be a
+number in `(0, 1]` — a fraction, so `0.9`, never `90`.
 
 **Validation gates:**
-- `enable_sub_batch_interleaving: true` requires `enable_attn_offloading: true` (enforced at config load time)
+- `enable_sub_batch_interleaving: true` requires `enable_attn_offloading: true`
+- `enable_sub_batch_interleaving: true` requires `pp_size == 1`: an interleaved trace leaves
+  both sub-batches mid-block at every stage edge, so a pipeline stage has no single hidden
+  state to pass on
+
+Both are enforced at config load time, against the *effective* values — so inheriting
+`--enable-sub-batch-interleaving` from the CLI onto an instance that locally sets
+`enable_attn_offloading: false` fails just the same.
 
 **Example: heterogeneous P/D instances**
 
-See `single_node_pd_per_instance_config.json` for a concrete example where the prefill instance uses `max_num_seqs: 32` (tight concurrency) and the decode instance uses `max_num_seqs: 256` (high throughput):
+`single_node_pd_per_instance_config.json` gives the prefill instance a tight
+concurrency and a large token budget, and the decode instance the reverse
+(hardware fields elided):
 
 ```json
 {
   "instances": [
     {
       "pd_type": "prefill",
+      "tp_size": 1,
       "max_num_seqs": 32,
       "max_num_batched_tokens": 8192,
-      "enable_chunked_prefill": true
+      "long_prefill_token_threshold": 2048,
+      "enable_chunked_prefill": true,
+      "block_size": 16,
+      "dtype": "bfloat16",
+      "kv_cache_dtype": "auto"
     },
     {
       "pd_type": "decode",
+      "tp_size": 1,
       "max_num_seqs": 256,
-      "max_num_batched_tokens": 0,
-      "enable_chunked_prefill": false
+      "max_num_batched_tokens": 256,
+      "enable_chunked_prefill": true,
+      "block_size": 16,
+      "dtype": "bfloat16",
+      "kv_cache_dtype": "auto"
     }
   ]
 }
 ```
+
+`single_node_heterogeneous.json` is the Qwen3-32B / TP=2 variant, and it does
+use `max_num_batched_tokens: 0` plus `enable_chunked_prefill: false` on the
+decode instance.
 
 ### Parallelism rules:
 - `num_npus = tp_size * pp_size`

--- a/configs/pim/README.md
+++ b/configs/pim/README.md
@@ -1,25 +1,57 @@
 # configs/pim
 
 PIM (Processing-In-Memory) device configuration files in DRAMSim3 INI format.
-Used by `pim_model.py` to compute PIM attention latency and power parameters.
+Used by `serving/core/pim_model.py` to derive memory capacity, bandwidth, and
+read latency, and to look up the calibrated PIM attention latency model.
 
 Enable PIM by setting `pim_config` in the cluster config's `cpu_mem` section and
 passing `--enable-attn-offloading` to `python -m serving`.
 
+Full schema, including which keys are inert:
+[Reference → PIM config](https://llmservingsim.ai/docs/reference/pim-config).
+
 ## Provided configs
 
-| Config | Protocol | Capacity | Speed | Description |
-| --- | --- | --- | --- | --- |
-| `DDR4_8GB_3200_pim.ini` | DDR4 | 8 GB | 3200 MT/s | DDR4 PIM module |
-| `HBM2_1GB_2000_pim.ini` | HBM2 | 1 GB | 2000 MT/s | HBM2 PIM module |
-| `LPDDR4X_2GB_4266_pim.ini` | LPDDR4X | 2 GB | 4266 MT/s | LPDDR4X PIM module |
-| `LPDDR5_2GB_6400_pim.ini` | LPDDR5 | 2 GB | 6400 MT/s | LPDDR5 PIM module |
+Capacity below is **per channel**, not the device total: how many channels a
+node has is derived from that node's `cpu_mem.mem_size`, not declared in the INI.
+
+| Config | `protocol` | Per-channel capacity | `data_rate` | Per-channel BW | Read latency |
+| --- | --- | --- | --- | --- | --- |
+| `DDR4_8GB_3200_pim.ini` | DDR4 | 8 GB | 3200 MT/s | 25.6 GB/s | 13.86 ns |
+| `HBM2_1GB_2000_pim.ini` | HBM | 1 GB | 2000 MT/s | 32.0 GB/s | 14.00 ns |
+| `LPDDR4X_2GB_4266_pim.ini` | LPDDR4X | 2 GB | 4266 MT/s | 8.53 GB/s | 16.85 ns |
+| `LPDDR5_2GB_6400_pim.ini` | LPDDR5 | 2 GB | 6400 MT/s | 12.80 GB/s | 10.62 ns |
 
 ## Key parameters
 
-The simulator extracts these from the INI files:
+`load_flat_config()` ignores `[section]` headers and flattens the whole file
+into one dict, so key names must be unique across the file. Of the ~50 keys in
+a bundled config, the simulator reads **eleven**:
 
-- **Bandwidth**: derived from `device_width`, `BL`, `tCK`, and channel count
-- **Latency**: derived from timing parameters (`tRCD`, `CL`, etc.)
-- **Capacity**: `rows * columns * device_width * banks * bankgroups`
-- **PIM type**: `pim_type` in `[dram_structure]` section (`SINGLE` or `DUAL`)
+- **Per-channel capacity** (`dimm_size`): from `bankgroups`, `banks_per_group`,
+  `rows`, `columns`, `device_width`, `bus_width`, and `channel_size`.
+  `channel_size` is a target in MB, snapped down to a whole number of ranks.
+- **Per-channel bandwidth**: `bus_width / 8 * data_rate / 1000` GB/s. `BL` and
+  `tCK` are *not* part of this.
+- **Channel count and aggregate bandwidth**:
+  `num_ch = cpu_mem.mem_size / per-channel capacity`, then
+  `mem_bw = num_ch * per-channel BW`. The `channels` key in `[system]` is
+  **not read**.
+- **Read latency**: `CL * tCK` ns. No other timing parameter is read.
+- **Power**: `idle_power` and `peak_power` from `[other]`, in **mW**. These are
+  LLMServingSim additions, not DRAMSim3 fields, and they are required.
+
+These derived values **overwrite** the node's `cpu_mem.mem_bw` and
+`cpu_mem.mem_latency` (with a warning). Only `cpu_mem.mem_size` still matters.
+
+`pim_type`, `BL`, `channels`, the `[power]` current rails, and every timing
+parameter other than `CL` / `tCK` are carried for DRAMSim3 fidelity and do not
+affect simulation.
+
+## Adding a config
+
+A new `.ini` alone is not enough. `pim_model.py::estimate_with_linear` matches
+the filename stem against a hard-coded table of calibrated
+`slope` / `intercept` coefficients, so you must also add an entry there —
+otherwise the first offloaded attention layer raises
+`ValueError: Unknown PIM spec: <stem>`.

--- a/docs/docs/artifact-evaluation.md
+++ b/docs/docs/artifact-evaluation.md
@@ -20,7 +20,7 @@ who want to reproduce the published figures end to end.
 | Paper | Venue | Branch | Reproduces |
 | --- | --- | --- | --- |
 | **LLMServingSim 2.0** | ISPASS 2026 | [`ispass26-artifact`](https://github.com/casys-kaist/LLMServingSim/tree/ispass26-artifact) | Figures 5–10 |
-| **LLMServingSim** | IISWC 2024 | (released artifact, see [Zenodo DOI](https://doi.org/10.5281/zenodo.12803583)) | Original paper figures |
+| **LLMServingSim** | IISWC 2024 | [`iiswc24-artifact`](https://github.com/casys-kaist/LLMServingSim/tree/iiswc24-artifact), also released on [Zenodo](https://doi.org/10.5281/zenodo.12803583) | Original paper figures |
 
 The CAL 2025 entry shares the ISPASS 2026 codebase and does not have
 its own artifact branch.

--- a/docs/docs/contributor/codebase-tour.md
+++ b/docs/docs/contributor/codebase-tour.md
@@ -80,10 +80,10 @@ profiler/
 
 | Intent | Edit |
 | --- | --- |
-| Add a new hardware target | Run the profiler with `HARDWARE=` set; output lands in `perf/<hw>/`. See **[Profiler / Adding hardware](/docs/profiler/adding-hardware)** |
+| Add a new hardware target | Run the profiler with `HARDWARE=` set; output lands in `profiler/perf/<hw>/`. See **[Profiler / Adding hardware](/docs/profiler/adding-hardware)** |
 | Add a new model architecture | Drop a YAML in `profiler/models/<model_type>.yaml`. See **[Profiler / Adding model architecture](/docs/profiler/adding-model-architecture)** |
-| Change the skew alpha fit | `core/fit_alpha.py` |
-| Change what categories get profiled | `core/categories.py` + `core/runner.py` |
+| Change the skew alpha fit | `profiler/core/fit_alpha.py` |
+| Change what categories get profiled | `profiler/core/categories.py` + `profiler/core/runner.py` |
 | Change output CSV columns | `core/writer.py` (and `_load_perf_db()` in `serving/core/trace_generator.py` to consume them) |
 
 ## Bench (`bench/`)
@@ -121,7 +121,7 @@ all. Field-by-field schema lives in
 ```
 workloads/
 ├── *.jsonl                  Datasets (one request or session per line)
-├── generators/              ShareGPT / SWE-bench JSONL builders
+├── generators/              JSONL builders. One subcommand today: `sharegpt`
 └── README.md                JSONL format reference
 ```
 

--- a/docs/docs/contributor/conventions.md
+++ b/docs/docs/contributor/conventions.md
@@ -96,9 +96,11 @@ preference:
    profiler bundle CSVs that exceed the gitignore patterns should
    stay local. The gitignore is set up; just don't `git add -A`.
 
-7. **Don't use `--no-verify` to bypass pre-commit hooks.** If a
-   hook fails, fix the underlying issue.
-
+7. **Don't rely on automation to catch you.** There are no
+   pre-commit hooks and no test CI: the only GitHub workflow is
+   `deploy-docs.yml`, which builds the docs site on pushes to `main`
+   that touch `docs/**`. Every check in
+   **[Validating your changes](./validating-changes)** is manual.
 8. **Don't add error handling for cases that can't happen.** Trust
    internal invariants; only validate at the boundaries (CLI args,
    JSON config load, dataset parsing). Defensive programming inside
@@ -124,6 +126,40 @@ These two trip up new contributors most often:
   bytes.** ASTRA-Sim divides by ring size internally. If you pass
   per-NPU sizes, every collective will be N times too small.
 
+## Scheduler invariants
+
+These are the ones with a history. Each has been broken before, and
+each cost real debugging time.
+
+- **There is no prefill phase and no decode phase.** A request just
+  catches up to `num_tokens_reached`, so
+  `num_new = num_tokens_reached - num_computed_tokens` — 1 in
+  steady-state decode, the whole remainder for a resumed request.
+  `Request.is_prefill()` was removed on purpose: it read
+  `original_input` and so misread a resumed request's recomputation as
+  decoding. Classify for the trace by **scheduled token count** (`> 1`
+  is a prefill chunk, `== 1` is decode), never by a phase flag.
+- **Never derive sequence length from `num_computed_tokens`.**
+  Preemption resets it to 0. `num_tokens_reached` is the independent
+  counter, mirroring vLLM's `len(_all_token_ids)`.
+- **`num_computed_tokens` advances at *schedule* time**, as in vLLM's
+  `_update_after_schedule`, and `Batch.scheduled_tokens` is the
+  snapshot `add_done` works from. Advancing it at completion instead
+  lets `pp_size > 1` schedule the same tokens twice.
+- **Don't add a "preserve the decode state on preemption" special
+  case.** `num_computed_tokens = 0` is vLLM's own behaviour and is not
+  re-prefill: `free_blocks` keeps the blocks' hashes, so on re-admission
+  `get_computed_blocks` finds whatever is still resident and a lower
+  tier returns what was written down. Only the remainder is recomputed.
+  Two earlier attempts to special-case this cost 375 preemptions /
+  293k recomputed tokens, and 41,569 preemptions / 6 TB of swap.
+- **Phase B never preempts, and is skipped entirely on any step that
+  preempted.** That anti-thrash rule is load-bearing; without it the
+  running set oscillates preempt → refill → preempt.
+- **There is one `schedule()`, for prefix caching on and off.** The pool
+  handles `enable_caching=False` the way vLLM does — allocate through
+  the same free list, never index — so do not add a second scheduler.
+
 ## Trace-format invariants
 
 If you touch `trace_generator.py` or `graph_generator.py`:
@@ -134,7 +170,25 @@ If you touch `trace_generator.py` or `graph_generator.py`:
   if either is `LOCAL` without local memory configured, ASTRA-Sim
   crashes.
 - The sampler's `output_loc` and `output_size` are what feed the
-  `MEM_STORE`. Don't put them on `lm_head`.
+  `MEM_STORE`. Don't put them on `lm_head`: what goes back to the host
+  is the sampled token ids, not the logits.
+- **A layer's `output_size` is not the next layer's `input_size`**, and
+  is not meant to be. `qkv_proj` emits Q+K+V while `rotary_emb` declares
+  only Q+K, and `attention` reads K/V from the cache rather than the
+  activation. There is no chain to "restore".
+- **Never split pipeline stages by trace-line count.** A stage may only
+  be cut on a transformer-block boundary, the one place where the
+  upstream `output_size` and downstream `input_size` are the same tensor
+  (the hidden state). ASTRA-Sim's analytical backend keys its send/recv
+  tracker on `(tag, src, dst, chunk_size, chunk_id)`, so a size mismatch
+  **silently deadlocks** the receiving NPU instead of raising. That is
+  what `pp_stage_boundaries` in the trace header exists for.
+- **Don't "restore" log-space interpolation** in `_axis_bracket`
+  because the profiler's sweep grid is geometric. Grid spacing decides
+  where the kernel is sampled; the blend decides how two samples
+  combine; the kernel is linear in each axis. Log blending biased
+  estimates 11.6-14.4% high against 2.3-3.7% for linear, measured
+  leave-one-out across every bundle in `profiler/perf/`.
 
 ## Commit and PR style
 

--- a/docs/docs/contributor/intro.md
+++ b/docs/docs/contributor/intro.md
@@ -95,9 +95,15 @@ python -m serving \
 
 What you should see:
 
-- A few seconds of throughput log lines
-  (`step=N batch=K prompt_t=… decode_t=…`).
-- A summary line at the end with totals (`Finished N requests`).
+- A startup banner, then a **KV Cache Initialization** line reporting
+  the derived capacity per instance.
+- A heartbeat every second: `[N.0s] Avg prompt throughput: … tokens/s,
+  Avg generation throughput: … tokens/s`, followed by an indented
+  `├─Running Instance[0]: … reqs, Waiting: … reqs, …` branch.
+- Ruled **Throughput Results** / **Prefix Caching Results** /
+  **Instance [0]** sections at the end, with `Total requests`,
+  `Total clocks (ns)`, and per-instance mean / median / P99 TTFT, TPOT
+  and ITL in milliseconds.
 - `outputs/onboarding_smoke.csv` containing one row per request.
 
 If you got that, the simulator is working. If you got an error, see

--- a/docs/docs/contributor/pr-workflow.md
+++ b/docs/docs/contributor/pr-workflow.md
@@ -35,7 +35,9 @@ git checkout -b add-deepseek-v3
 - **Don't amend published commits.** If you pushed it, follow up
   with a new commit. Force-pushing your branch is fine *before*
   review starts, generally not after.
-- **No `--no-verify`** to bypass pre-commit hooks. Fix what failed.
+- **There are no pre-commit hooks** in this repo, so nothing runs
+  automatically on commit and `--no-verify` has nothing to bypass. The
+  checks below are yours to run.
 - **No `Co-authored-by`** unless someone really did pair-program
   with you on this commit.
 
@@ -163,11 +165,12 @@ PR. The maintainer adds it on merge.
 - **Delete the merged branch** locally and on the remote
   (GitHub offers a button after merge; `git branch -d add-deepseek-v3`
   locally).
-- **Watch CI on `main` for a day or two**. If something broke that
-  the PR didn't catch, you're best positioned to fix it quickly.
-
-## When things go wrong
-
+- **Re-run your scenarios against `main` after the merge.** There is
+  no test CI to watch: the only workflow is `deploy-docs.yml`, which
+  builds the docs site and says nothing about the simulator. If
+  something broke that the review missed, the way you find out is by
+  running `serving/run.sh`'s relevant scenarios on `main` and comparing
+  `Total clocks (ns)` against what you recorded before.
 - **My PR sat for a week with no reviews.** Ping the PR with a
   one-liner. Maintainers do miss notifications.
 - **A reviewer requested changes I disagree with.** Explain your

--- a/docs/docs/contributor/validating-changes.md
+++ b/docs/docs/contributor/validating-changes.md
@@ -27,8 +27,29 @@ What to check:
 
 - Exit code is 0.
 - `outputs/smoke.csv` has 10 rows plus a header.
-- The throughput log line at the end shows non-zero `prompt_t` and
-  `decode_t`.
+- The final **Throughput Results** block shows non-zero
+  `Average prompt throughput (tok/s)` and
+  `Average generation throughput (tok/s)`.
+
+:::tip Use `Total clocks (ns)` as the actual regression test
+The simulator is deterministic: the same cluster config, workload and
+flags reproduce the same makespan **exactly**. So the useful check is
+not "does it look sensible" but equality against the value on `main`:
+
+```bash
+python -m serving ... 2>&1 | grep 'Total clocks'
+```
+
+Any diff in that number means your change altered simulated behaviour.
+That is fine when it is the point of the change — say so in the PR, with
+the before and after — and a bug when it is not. A refactor that claims
+to be behaviour-preserving and moves this number is not
+behaviour-preserving.
+
+Capture it for every scenario you touch before you start editing;
+recovering the baseline afterwards means stashing your work and
+re-running.
+:::
 
 If your change is in `serving/`, this is the floor. Don't push a
 commit that breaks the smoke run.
@@ -81,11 +102,18 @@ Output lands in `bench/examples/Llama-3.1-8B/validation/`:
 - A handful of PDFs: per-request latency CDF, throughput timeline,
   running-waiting curves.
 
-The committed reference baselines target sub-3% error on TTFT, TPOT,
-and throughput. **A regression beyond ~5% is a blocker.** Smaller
-movements need an explanation in the PR description (e.g., "this
-fixes an under-counting bug; the new error is closer to ground
+The committed reference baselines land within 1.5% on TPOT and
+end-to-end latency means and within 5.8% on TTFT means — see
+**[Validation](/docs/validation)** for the per-configuration table.
+**A regression beyond ~5% against those baselines is a blocker.**
+Smaller movements need an explanation in the PR description (e.g.,
+"this fixes an under-counting bug; the new error is closer to ground
 truth than the old").
+
+Compare against the numbers in
+`bench/examples/<model>/validation/summary.txt`, not against the ~5%
+figure in the abstract: TTFT already sits at -5.8% on the MoE
+configuration, so "within 5%" is not a bar it currently clears.
 
 For deeper detail on the validation methodology, see
 [`bench/README.md`](https://github.com/casys-kaist/LLMServingSim/blob/main/bench/README.md).

--- a/docs/docs/contributor/welcome.mdx
+++ b/docs/docs/contributor/welcome.mdx
@@ -23,8 +23,9 @@ It's an open-source project from
 **[Prof. Jongse Park](https://jongse-park.github.io/)'s research
 group** at **[KAIST CASYS Lab](https://casys.kaist.ac.kr/)**,
 peer-reviewed at three venues over the last two years, and validated
-end-to-end against real vLLM with sub-3% error on TTFT, TPOT, and
-throughput.
+end-to-end against real vLLM: on all three bundled configurations, TPOT
+and end-to-end latency means land within 1.5%, and TTFT means within
+5.8%. See **[Validation](/docs/validation)**.
 
 **We're actively looking for contributors.** Not "PRs welcome"
 boilerplate, actual collaborators who shape where this project

--- a/docs/docs/examples/advanced/power-modeling.md
+++ b/docs/docs/examples/advanced/power-modeling.md
@@ -88,17 +88,28 @@ run that doesn't track power.
 
 ## Expected output
 
-The throughput log gains a `power=` field (in watts):
+The heartbeat block gains a final `Avg power consumption` branch:
 
 ```text
-[INFO] step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s
-       npu_mem=88.4 GB power=712 W
-[INFO] step=43 batch=8 prompt_t=1.1k tok/s decode_t=440 tok/s
-       npu_mem=88.4 GB power=698 W
+[42.0s] Avg prompt throughput: 1204.0 tokens/s, Avg generation throughput: 420.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 88412.34 MB (89.912 % Used), Prefix Cache Hit ratio 4.21 %, (5312 / 126188)
+        ├─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+        └─Avg power consumption: 712.4 W
+[43.0s] Avg prompt throughput: 1138.0 tokens/s, Avg generation throughput: 440.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 88412.34 MB (89.912 % Used), Prefix Cache Hit ratio 4.19 %, (5312 / 126780)
+        ├─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+        └─Avg power consumption: 698.1 W
 ```
 
-`power` is the **instantaneous** total node power summed across
-NPU / CPU / DRAM / link / NIC / storage / base.
+Two things the label does not say. It is an **interval average**, not an
+instantaneous reading: `get_current_power()` divides the energy accrued
+since the previous heartbeat by the elapsed time. And it is a single
+**cluster-wide** figure summed over every node, not per node — so on a
+multi-node run you cannot attribute it from this line. The per-node
+split arrives only in the final summary.
+
+The figure covers NPU, CPU, DRAM, link, NIC, storage, and each node's
+always-on base power.
 
 When the run ends, the simulator prints a per-component energy
 breakdown:
@@ -144,9 +155,9 @@ ALLREDUCE-bound (worth checking when `tp_size > 1`).
   cleanly with the power model. Overlapping PIM attention with GPU
   compute changes both throughput and the energy breakdown.
 - **[CXL memory](../memory-tiers/cxl-memory)** — adding a `cxl_mem`
-  device and per-device placement rules adds a `cxl_mem=...` field
-  to the throughput log; the energy summary then includes CXL
-  transfer energy.
+  device and per-device placement rules adds a `CXL[...]` branch to the
+  heartbeat block (only with `--prefix-storage CXL`); the energy
+  summary then includes CXL transfer energy.
 
 ## Where to learn more
 

--- a/docs/docs/examples/advanced/sub-batch-interleaving.md
+++ b/docs/docs/examples/advanced/sub-batch-interleaving.md
@@ -64,18 +64,23 @@ than emitting a graph that cannot be scheduled.
 
 ## Expected output
 
-The throughput log shows both devices loaded:
+The heartbeat block is unchanged in shape:
 
 ```text
-[INFO] step=10 batch=8 prompt_t=1.4k tok/s decode_t=620 tok/s
-       npu_mem=63.4 GB pim_busy=78% gpu_busy=82%
-[INFO] step=11 batch=8 prompt_t=1.4k tok/s decode_t=640 tok/s
-       npu_mem=63.4 GB pim_busy=80% gpu_busy=80%
+[10.0s] Avg prompt throughput: 1436.0 tokens/s, Avg generation throughput: 620.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63412.51 MB (64.499 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 14360)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+[11.0s] Avg prompt throughput: 1442.0 tokens/s, Avg generation throughput: 640.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63486.51 MB (64.574 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 15802)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
-Compare against the pure-PIM run (without `--enable-sub-batch-interleaving`):
-the GPU previously had long idle stretches while waiting on PIM;
-now both `pim_busy` and `gpu_busy` plateau in the high 70s / 80s.
+There are **no `pim_busy` / `gpu_busy` fields** — the simulator tracks
+no device utilization counters. Interleaving overlaps the NPU and PIM
+halves of the iteration inside the emitted trace, so the only visible
+effect is a shorter iteration: higher generation throughput and lower
+TPOT than the same config without `--enable-sub-batch-interleaving`.
+Run both and compare the final `Mean TPOT (ms)` line.
 
 `outputs/pim_sub_batch_run.csv` has the same per-request schema as
 any other run; what changes is the per-iteration latency, not the

--- a/docs/docs/examples/cluster-config-explained.mdx
+++ b/docs/docs/examples/cluster-config-explained.mdx
@@ -171,6 +171,132 @@ gets inferred. So:
 | Field | Used for |
 | --- | --- |
 | `placement` | Per-layer / per-block weight + KV-cache placement (see [CXL memory](./memory-tiers/cxl-memory)) |
+| any of the 14 runtime overrides | Per-instance scheduler / memory / dtype settings (see below) |
+
+## Per-instance runtime overrides
+
+Everything so far describes *hardware*. An instance can also carry
+**runtime settings**, and that is what makes heterogeneous clusters
+possible: 14 of the `python -m serving` flags can be re-specified per
+instance, so a prefill instance and a decode instance in the same run
+can be scheduled completely differently.
+
+The precedence is one level deep:
+
+```
+instances[i].<field>   >   --<field> on the CLI   >   built-in default
+```
+
+A field written in the instance wins for that instance. Every other
+instance keeps whatever the CLI said. There is no merging and no
+inheritance between instances.
+
+### The 14 overridable fields
+
+| Field | Overrides | Typical reason to set it per instance |
+| --- | --- | --- |
+| `max_num_seqs` | `--max-num-seqs` | Narrow batches on a prefill instance, wide ones on decode |
+| `max_num_batched_tokens` | `--max-num-batched-tokens` | Big prefill chunks, small decode steps |
+| `long_prefill_token_threshold` | `--long-prefill-token-threshold` | Stop one long prompt monopolising a prefill instance |
+| `block_size` | `--block-size` | Coarser blocks where fragmentation matters less |
+| `dtype` | `--dtype` | Serve the same model at two precisions |
+| `kv_cache_dtype` | `--kv-cache-dtype` | FP8 KV on the decode instance only |
+| `enable_chunked_prefill` | `--enable-chunked-prefill` | Chunk on prefill, never on decode |
+| `enable_prefix_caching` | `--enable-prefix-caching` | Cache where prefixes repeat, skip where they don't |
+| `npu_mem.mem_util` | `--npu-memory-utilization` | Leave headroom on one instance only |
+| `reserve_full_isl` | `--reserve-full-isl` | Loosen admission on a decode-only instance |
+| `enable_local_offloading` | `--enable-local-offloading` | Weight offload on one instance |
+| `enable_attn_offloading` | `--enable-attn-offloading` | PIM attention on one instance |
+| `enable_sub_batch_interleaving` | `--enable-sub-batch-interleaving` | Overlap NPU and PIM on the offloading instance |
+| `enable_block_copy` | `--enable-block-copy` | Faithful per-layer expert variance on one instance |
+
+Note where `mem_util` sits: it is the **only** override nested inside
+another object, because it exists to scale `npu_mem.mem_size` and
+follows that block's `mem_*` naming.
+
+```json
+"npu_mem": {"mem_size": 96, "mem_bw": 1597, "mem_latency": 0, "mem_util": 0.8}
+```
+
+### A heterogeneous example
+
+`configs/cluster/single_node_heterogeneous.json` runs one Qwen3-32B
+prefill instance and one decode instance, both TP=2, with opposite
+scheduler settings:
+
+```json title="configs/cluster/single_node_heterogeneous.json (instances only)"
+"instances": [
+  {
+    "model_name": "Qwen/Qwen3-32B",
+    "hardware": "RTXPRO6000",
+    "npu_mem": {"mem_size": 96, "mem_bw": 1597, "mem_latency": 0},
+    "num_npus": 2,
+    "tp_size": 2,
+    "pd_type": "prefill",
+    "max_num_seqs": 32,
+    "max_num_batched_tokens": 8192,
+    "enable_chunked_prefill": true,
+    "enable_prefix_caching": true
+  },
+  {
+    "model_name": "Qwen/Qwen3-32B",
+    "hardware": "RTXPRO6000",
+    "npu_mem": {"mem_size": 96, "mem_bw": 1597, "mem_latency": 0},
+    "num_npus": 2,
+    "tp_size": 2,
+    "pd_type": "decode",
+    "max_num_seqs": 256,
+    "max_num_batched_tokens": 0,
+    "enable_chunked_prefill": false,
+    "enable_prefix_caching": false
+  }
+]
+```
+
+Reading it: the prefill instance takes few sequences with a large
+token budget, because a prefill step wants long chunks. The decode
+instance takes many sequences and no token cap, because each decode
+step contributes one token per sequence.
+
+`configs/cluster/single_node_pd_per_instance_config.json` is the
+Llama-3.1-8B version of the same idea, and additionally overrides
+`long_prefill_token_threshold`, `block_size`, `dtype`, and
+`kv_cache_dtype`.
+
+:::caution `max_num_batched_tokens: 0` is not infinity
+`0` maps to "unlimited", but the scheduler then applies
+`min(max_num_batched_tokens, max_position_embeddings)`. On Qwen3-32B
+that is 40960, so the decode instance above runs at 40960, not
+unbounded. See **[Model config](/docs/reference/model-config)**.
+:::
+
+### What you cannot set per instance
+
+The other 15 flags are cluster-wide. Writing one inside an instance
+object does nothing at all: no key reads it, and no error is raised.
+
+| Scope | Flags |
+| --- | --- |
+| Cluster / backend | `--cluster-config`, `--network-backend` |
+| Router, cross-instance by definition | `--request-routing-policy`, `--expert-routing-policy` |
+| Shared lower KV tier | `--enable-prefix-sharing`, `--prefix-storage` |
+| Workload, one per run | `--dataset`, `--num-reqs`, `--skip-prefill` |
+| Run plumbing | `--output`, `--run-id`, `--inputs-root`, `--cleanup-inputs`, `--log-interval`, `--log-level` |
+
+### Two rejected combinations
+
+Both are checked per instance, against the *effective* values, at
+config-load time:
+
+- `enable_sub_batch_interleaving` without `enable_attn_offloading` -
+  there is nothing to overlap the NPU sub-batch against.
+- `enable_sub_batch_interleaving` with `pp_size > 1`: an interleaved
+  trace leaves both sub-batches mid-block at every stage edge, so a
+  pipeline stage has no single hidden state to hand on.
+
+Full semantics, including `dtype`'s three-level fallback and the
+`mem_util` range check, are in
+**[Reference → Cluster config](/docs/reference/cluster-config#runtime-overrides-optional)**.
 
 ## DP+EP, the topology that needs more explanation
 
@@ -208,23 +334,31 @@ the cluster config.
 
 ## Provided configs
 
-The repo ships 15 worked configs under `configs/cluster/`. Each
-example in this section uses one of them:
+The repo ships **20** worked configs under `configs/cluster/`. Those
+without a link are runnable as-is but have no dedicated example page:
 
-| Config | Used by |
-| --- | --- |
-| `single_node_single_instance.json` | [Tensor parallel](./parallelism/tensor-parallel) (with `tp_size=2`) |
-| `single_node_multi_instance.json` | [Multi-instance LOAD routing](./disaggregated/multi-instance) |
-| `single_node_pd_instance.json` | [Prefill/decode split](./disaggregated/prefill-decode-split) |
-| `single_node_pd_per_instance_config.json` | P/D split with per-instance runtime limits |
-| `single_node_moe_single_instance.json` | [Expert parallel](./parallelism/expert-parallel) |
-| `single_node_moe_dp_ep_instance.json` | [DP+EP MoE](./parallelism/dp-ep-moe) |
-| `single_node_cxl_instance.json` | [CXL memory tier](./memory-tiers/cxl-memory) |
-| `single_node_pim_instance.json` | [PIM attention offload](./disaggregated/pim-attention-offload) |
-| `single_node_power_instance.json` | [Power modeling](./advanced/power-modeling) |
-| `dual_node_multi_instance.json` | Multi-node setups |
-| `dual_node_moe_dp_ep_intra_inter_instance.json` | Two-node DP+EP MoE with per-dimension intra/inter `link_bw` / `link_latency` |
-| ... | ... |
+| Config | Shape | Used by |
+| --- | --- | --- |
+| `single_node_single_instance.json` | 1 node, 1 instance, Llama-3.1-8B, TP=1 | the default; [Tensor parallel](./parallelism/tensor-parallel) raises it to `tp_size=2` |
+| `single_node_single_instance_H100.json` | Llama-3.1-70B on H100, TP=4 | — |
+| `single_node_multi_instance.json` | 1 node, 2 instances | [Multi-instance LOAD routing](./disaggregated/multi-instance) |
+| `single_node_4_instance_2TP.json` | 1 node, 4 instances at TP=2 | — |
+| `single_node_heterogeneous.json` | P/D pair with opposite runtime settings | [Per-instance runtime overrides](#per-instance-runtime-overrides) |
+| `single_node_pd_instance.json` | prefill/decode disaggregation | [Prefill/decode split](./disaggregated/prefill-decode-split) |
+| `single_node_pd_per_instance_config.json` | P/D with per-instance runtime limits | [Per-instance runtime overrides](#per-instance-runtime-overrides) |
+| `single_node_pp_instance.json` | 4 GPUs as `pp=4` | [Pipeline parallel](./parallelism/pipeline-parallel) |
+| `single_node_tp_pp_instance.json` | 4 GPUs as `tp=2 x pp=2` | [Pipeline parallel](./parallelism/pipeline-parallel) |
+| `single_node_moe_single_instance.json` | Qwen3-MoE, TP=2 EP=2 | [Expert parallel](./parallelism/expert-parallel) |
+| `single_node_moe_dp_ep_instance.json` | 2 MoE instances in one DP group, EP=2 | [DP+EP MoE](./parallelism/dp-ep-moe) |
+| `single_node_moe_multi_instance.json` | 2 MoE instances, no DP group | — |
+| `single_node_moe_pd_instance.json` | MoE with P/D disaggregation | — |
+| `single_node_moe_pp_instance.json` | MoE on 4 GPUs, `tp=2 x pp=2`, `ep=2` | [Pipeline parallel](./parallelism/pipeline-parallel) |
+| `single_node_cxl_instance.json` | CXL memory expansion | [CXL memory tier](./memory-tiers/cxl-memory) |
+| `single_node_memory_instance.json` | weight / KV `placement` control | [CXL memory tier](./memory-tiers/cxl-memory) |
+| `single_node_pim_instance.json` | PIM-enabled memory + power model | [PIM attention offload](./disaggregated/pim-attention-offload) |
+| `single_node_power_instance.json` | power modeling enabled | [Power modeling](./advanced/power-modeling) |
+| `dual_node_multi_instance.json` | 2 nodes, 2 instances each | multi-node setups |
+| `dual_node_moe_dp_ep_intra_inter_instance.json` | 2-node DP+EP MoE, per-dimension `link_bw` / `link_latency` | [DP+EP MoE](./parallelism/dp-ep-moe) |
 
 ## What's next
 

--- a/docs/docs/examples/disaggregated/multi-instance.mdx
+++ b/docs/docs/examples/disaggregated/multi-instance.mdx
@@ -82,10 +82,14 @@ clarity. Options:
 ## Expected output
 
 ```text
-[INFO] step=20 inst0_batch=6 inst1_batch=4 prompt_t=2.4k tok/s decode_t=820 tok/s
-       npu_mem=[63.2 GB, 63.2 GB]
-[INFO] step=21 inst0_batch=6 inst1_batch=5 prompt_t=2.5k tok/s decode_t=860 tok/s
-       npu_mem=[63.2 GB, 63.2 GB]
+[20.0s] Avg prompt throughput: 2412.0 tokens/s, Avg generation throughput: 820.0 tokens/s
+        ├─Running Instance[0]: 6 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63218.51 MB (64.301 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 74208)
+        ├─Running Instance[1]: 4 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63204.51 MB (64.287 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 71950)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
+[21.0s] Avg prompt throughput: 2508.0 tokens/s, Avg generation throughput: 860.0 tokens/s
+        ├─Running Instance[0]: 6 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63290.51 MB (64.374 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 75462)
+        ├─Running Instance[1]: 5 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63276.51 MB (64.360 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 73204)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
 ```
 
 The router fills the lighter-loaded instance first. With LOAD policy,

--- a/docs/docs/examples/disaggregated/pim-attention-offload.mdx
+++ b/docs/docs/examples/disaggregated/pim-attention-offload.mdx
@@ -88,14 +88,20 @@ attention kernel from the NPU profile to the PIM profile. The rest
 ## Expected output
 
 ```text
-[INFO] step=10 batch=8 prompt_t=1.1k tok/s decode_t=520 tok/s
-       npu_mem=63.4 GB pim_busy=72%
-[INFO] step=11 batch=8 prompt_t=1.1k tok/s decode_t=540 tok/s
-       npu_mem=63.4 GB pim_busy=78%
+[10.0s] Avg prompt throughput: 1104.0 tokens/s, Avg generation throughput: 520.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63412.51 MB (64.499 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 11040)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+[11.0s] Avg prompt throughput: 1138.0 tokens/s, Avg generation throughput: 540.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63486.51 MB (64.574 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 12178)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
-`pim_busy` reports the PIM device's utilization, when this
-plateaus near 100% you've found the PIM bottleneck for the workload.
+**The heartbeat has no PIM field.** Offloading changes attention's
+`comp_time` inside the trace, so its effect shows up as generation
+throughput and TPOT, not as a utilization counter. To see whether PIM
+is the bottleneck, compare TPOT against the same workload without
+`--enable-attn-offloading`, or inspect a trace with
+`--no-cleanup-inputs` and look at the `PIM` marker blocks.
 
 ## What's interesting
 

--- a/docs/docs/examples/disaggregated/prefill-decode-split.mdx
+++ b/docs/docs/examples/disaggregated/prefill-decode-split.mdx
@@ -82,10 +82,14 @@ python -m serving \
 ## Expected output
 
 ```text
-[INFO] step=15 P=8 D=12 prompt_t=3.1k tok/s decode_t=620 tok/s
-       npu_mem=[55.4 GB, 71.2 GB]
-[INFO] step=16 P=10 D=12 prompt_t=3.6k tok/s decode_t=640 tok/s
-       npu_mem=[55.4 GB, 71.4 GB]
+[15.0s] Avg prompt throughput: 3104.0 tokens/s, Avg generation throughput: 620.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 2 reqs, Total # 1 NPUs, Each NPU Memory Usage 55412.51 MB (56.360 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 46560)
+        ├─Running Instance[1]: 12 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 71238.51 MB (72.454 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 0)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
+[16.0s] Avg prompt throughput: 3612.0 tokens/s, Avg generation throughput: 640.0 tokens/s
+        ├─Running Instance[0]: 10 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 55486.51 MB (56.435 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 50172)
+        ├─Running Instance[1]: 12 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 71402.51 MB (72.621 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 0)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
 ```
 
 The `P=` and `D=` counts are per-role batch sizes. The decode

--- a/docs/docs/examples/memory-tiers/cxl-memory.mdx
+++ b/docs/docs/examples/memory-tiers/cxl-memory.mdx
@@ -122,11 +122,19 @@ python -m serving \
 ## Expected output
 
 ```text
-[INFO] step=10 batch=4 prompt_t=620 tok/s decode_t=180 tok/s
-       npu_mem=12.4 GB cxl_mem=[3.2 GB, 3.1 GB, 3.1 GB, 3.2 GB]
-[INFO] step=11 batch=4 prompt_t=640 tok/s decode_t=190 tok/s
-       npu_mem=12.4 GB cxl_mem=[3.2 GB, 3.1 GB, 3.1 GB, 3.2 GB]
+[10.0s] Avg prompt throughput: 624.0 tokens/s, Avg generation throughput: 180.0 tokens/s
+        ├─Running Instance[0]: 4 reqs, Waiting: 1 reqs, Total # 1 NPUs, Each NPU Memory Usage 12412.51 MB (12.622 % Used), Prefix Cache Hit ratio 12.40 %, (3712 / 29944)
+        ├─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+        └─CXL[0]/Instance[0]: Total CXL Device Memory Usage 3276.80 MB, 3.200 % Used
+[11.0s] Avg prompt throughput: 641.0 tokens/s, Avg generation throughput: 190.0 tokens/s
+        ├─Running Instance[0]: 4 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 12486.51 MB (12.697 % Used), Prefix Cache Hit ratio 12.88 %, (4096 / 31801)
+        ├─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+        └─CXL[0]/Instance[0]: Total CXL Device Memory Usage 3379.20 MB, 3.300 % Used
 ```
+
+The `CXL[0]/Instance[0]` form is what you get **without**
+`--enable-prefix-sharing`: one branch per prefix-caching instance. With
+sharing on, the branches become `CXL[i]`, one per device.
 
 `npu_mem` is dramatically lower than the NPU-only baseline because
 weights live on CXL. `cxl_mem` is reported per-device.

--- a/docs/docs/examples/memory-tiers/fp8-kv-cache.md
+++ b/docs/docs/examples/memory-tiers/fp8-kv-cache.md
@@ -16,7 +16,7 @@ sidebar_position: 3
    `<dtype>` (e.g., `bf16`) to `<dtype>-kvfp8` (e.g., `bf16-kvfp8`),
    so attention latency comes from the FP8-KV profile bundle.
 2. **Memory model** halves the per-block KV cache byte count
-   (`bytes_per_block` uses `kv_fp_size = 1` instead of `2`), so the
+   (`bytes_per_block` uses `kv_fp = 1` instead of `2`), so the
    scheduler can fit roughly 2× as many active tokens at the same
    `npu_mem`.
 
@@ -98,8 +98,9 @@ The throughput log looks unchanged in shape, but the memory
 footprint at the same batch size is much smaller:
 
 ```text
-[INFO] step=42 batch=16 prompt_t=2.4k tok/s decode_t=860 tok/s
-       npu_mem=68.2 GB
+[42.0s] Avg prompt throughput: 2416.0 tokens/s, Avg generation throughput: 860.0 tokens/s
+        ├─Running Instance[0]: 16 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 68204.26 MB (69.362 % Used), Prefix Cache Hit ratio 3.18 %, (4096 / 128704)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
 For comparison, the same workload on the same machine with
@@ -136,7 +137,7 @@ half of the per-token memory cost is gone.
 ## Where to learn more
 
 - **[Simulator → KV cache & memory](/docs/simulator/scheduling/kv-cache-and-memory)**:
-  the `bytes_per_block` formula and how `kv_fp_size` flows into
+  the `bytes_per_block` formula and how `kv_fp` flows into
   the scheduler's memory check.
 - **[Profiler → Output bundle](/docs/profiler/output-bundle)**:
   variant naming (`bf16` vs. `bf16-kvfp8` vs. `fp8` vs.

--- a/docs/docs/examples/memory-tiers/prefix-caching.mdx
+++ b/docs/docs/examples/memory-tiers/prefix-caching.mdx
@@ -106,9 +106,16 @@ With the shared CPU pool enabled, the throughput log gains prefix
 hit-rate counters:
 
 ```text
-[INFO] step=20 inst0_batch=6 inst1_batch=4 prompt_t=2.4k tok/s decode_t=820 tok/s
-       prefix_hit=78% (npu=42%, cpu=36%)
+[20.0s] Avg prompt throughput: 2412.0 tokens/s, Avg generation throughput: 820.0 tokens/s
+        ├─Running Instance[0]: 6 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63218.51 MB (64.301 % Used), Prefix Cache Hit ratio 41.82 %, (31024 / 74208)
+        ├─Running Instance[1]: 4 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 63204.51 MB (64.287 % Used), Prefix Cache Hit ratio 42.11 %, (30298 / 71950)
+        └─Node[0]: Total CPU Memory Usage 8192.00 MB, 1.600 % Used, Prefix Cache Hit ratio 36.04 %, (52664 / 146158)
 ```
+
+The per-instance ratios are NPU-tier hits; the ratio on the `Node`
+line is the shared CPU pool's, and it replaces the per-instance CPU
+split because `--enable-prefix-sharing --prefix-storage CPU` makes the
+pool node-wide.
 
 The `prompt_t` (prompt throughput) counts **all** input tokens,
 including those served from cache, matching vLLM's reporting

--- a/docs/docs/examples/parallelism/dp-ep-moe.mdx
+++ b/docs/docs/examples/parallelism/dp-ep-moe.mdx
@@ -79,7 +79,7 @@ python -m serving \
   --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl' \
   --output 'outputs/dp_ep_moe_run.csv' \
-  --num-req 1
+  --num-reqs 1
 ```
 
 Notes on the flags:
@@ -87,17 +87,28 @@ Notes on the flags:
 - The bundled SWE-bench-style agentic dataset is a good fit because
   each session has multiple chained sub-requests, which keeps both
   instances active.
-- `--num-req 1` means one *session* (multiple sub-requests). Bump it
+- `--num-reqs 1` means one *session* (multiple sub-requests). Bump it
   up for a longer run.
 
 ## Expected output
 
 ```text
-[INFO] step=8 batch=4+4 prompt_t=1.4k tok/s decode_t=520 tok/s
-       npu_mem=[81.2 GB, 81.2 GB] alltoall=512 KB
-[INFO] step=9 batch=4+4 prompt_t=1.5k tok/s decode_t=540 tok/s
-       npu_mem=[81.2 GB, 81.2 GB] alltoall=512 KB
+[4.0s] Avg prompt throughput: 9063.0 tokens/s, Avg generation throughput: 1074.0 tokens/s
+        ├─Running Instance[0]: 23 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 32634.88 MB (33.198 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 20285)
+        ├─Running Instance[1]: 22 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 32981.38 MB (33.550 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 24147)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
+[5.0s] Avg prompt throughput: 5342.0 tokens/s, Avg generation throughput: 1504.0 tokens/s
+        ├─Running Instance[0]: 27 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 32987.38 MB (33.556 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 23234)
+        ├─Running Instance[1]: 26 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 33312.88 MB (33.888 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 26861)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
 ```
+
+Those two lines are copied from
+[`bench/examples/Qwen3-30B-A3B-Instruct-2507/outputs/sim.log`](https://github.com/casys-kaist/LLMServingSim/tree/main/bench/examples),
+the committed DP+EP validation run. Nothing in the heartbeat names the
+ALLTOALL or the DP group: wave synchronisation shows up only as the two
+instances advancing in lockstep, which is why their `Running` counts
+stay within one of each other.
 
 The `batch=4+4` notation reflects per-instance batch (instance 0 +
 instance 1). The `alltoall` field shows the wave-synchronized

--- a/docs/docs/examples/parallelism/expert-parallel.mdx
+++ b/docs/docs/examples/parallelism/expert-parallel.mdx
@@ -84,8 +84,12 @@ python -m serving \
 ## Expected output
 
 ```text
-[INFO] step=10 batch=4 prompt_t=900 tok/s decode_t=320 tok/s npu_mem=72.1 GB
-[INFO] step=11 batch=4 prompt_t=920 tok/s decode_t=330 tok/s npu_mem=72.1 GB
+[10.0s] Avg prompt throughput: 903.0 tokens/s, Avg generation throughput: 320.0 tokens/s
+        ├─Running Instance[0]: 4 reqs, Waiting: 0 reqs, Total # 2 NPUs, Each NPU Memory Usage 72104.88 MB (73.298 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 9142)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+[11.0s] Avg prompt throughput: 921.0 tokens/s, Avg generation throughput: 330.0 tokens/s
+        ├─Running Instance[0]: 4 reqs, Waiting: 0 reqs, Total # 2 NPUs, Each NPU Memory Usage 72180.88 MB (73.375 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 10063)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
 Compared to a hypothetical TP=2 EP=1 run on the same model: each

--- a/docs/docs/examples/parallelism/pipeline-parallel.md
+++ b/docs/docs/examples/parallelism/pipeline-parallel.md
@@ -77,7 +77,7 @@ python -m serving \
   --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/example_trace.jsonl' \
   --output 'outputs/example_pp_run.csv' \
-  --num-req 10
+  --num-reqs 10
 ```
 
 No new CLI flag, the parallelism degree is fully driven by the
@@ -89,8 +89,12 @@ cluster config. Swap in `single_node_tp_pp_instance.json` or
 The throughput log looks like a standard single-instance run:
 
 ```text
-[INFO] step=20 batch=8 prompt_t=1.4k tok/s decode_t=540 tok/s npu_mem=44.0 GB
-[INFO] step=21 batch=8 prompt_t=1.5k tok/s decode_t=560 tok/s npu_mem=44.1 GB
+[20.0s] Avg prompt throughput: 1436.0 tokens/s, Avg generation throughput: 540.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 4 NPUs, Each NPU Memory Usage 44032.19 MB (44.774 % Used), Prefix Cache Hit ratio 1.02 %, (1424 / 139612)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+[21.0s] Avg prompt throughput: 1502.0 tokens/s, Avg generation throughput: 560.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 4 NPUs, Each NPU Memory Usage 44118.19 MB (44.861 % Used), Prefix Cache Hit ratio 1.01 %, (1424 / 141114)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
 Two things to notice vs. the TP=1 baseline:

--- a/docs/docs/examples/parallelism/tensor-parallel.mdx
+++ b/docs/docs/examples/parallelism/tensor-parallel.mdx
@@ -24,7 +24,7 @@ attention `o_proj` and MLP `down_proj` ends with an ALLREDUCE.
 `configs/cluster/single_node_single_instance.json` (lightly edited
 from the bundled config to use `Qwen/Qwen3-32B` at `tp_size=2`):
 
-```json title="configs/cluster/single_node_single_instance.json"
+```json title="configs/cluster/single_node_single_instance.json (edited: Qwen3-32B at tp_size=2)"
 {
   "num_nodes": 1,
   "link_bw": 16,
@@ -74,8 +74,12 @@ python -m serving \
 Throughput logs land roughly once per second:
 
 ```text
-[INFO] step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s npu_mem=88.4 GB
-[INFO] step=43 batch=8 prompt_t=1.1k tok/s decode_t=440 tok/s npu_mem=88.4 GB
+[42.0s] Avg prompt throughput: 1204.0 tokens/s, Avg generation throughput: 420.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 2 NPUs, Each NPU Memory Usage 88412.34 MB (89.912 % Used), Prefix Cache Hit ratio 4.21 %, (5312 / 126188)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+[43.0s] Avg prompt throughput: 1138.0 tokens/s, Avg generation throughput: 440.0 tokens/s
+        ├─Running Instance[0]: 8 reqs, Waiting: 0 reqs, Total # 2 NPUs, Each NPU Memory Usage 88412.34 MB (89.912 % Used), Prefix Cache Hit ratio 4.19 %, (5312 / 126780)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
 `outputs/tp2_run.csv` has one row per finished request. The

--- a/docs/docs/getting-started/installation/prerequisites.md
+++ b/docs/docs/getting-started/installation/prerequisites.md
@@ -16,7 +16,7 @@ CPU, but the profiler and the vLLM benchmark need an NVIDIA GPU.
 | **Docker** | ✓ | ✓ (or bare-metal install) |
 | **NVIDIA GPU** |  | ✓ |
 | **NVIDIA Container Toolkit** |  | ✓ (for GPU passthrough into Docker) |
-| **CUDA driver** |  | 13.x or compatible |
+| **CUDA driver** |  | 12.x for the default `vllm/vllm-openai:v0.19.0` image; 13.x needs the `v0.19.0-cu130` tag instead |
 | **Disk** | ~3 GB | ~10 GB additional (vLLM image + HF model cache) |
 | **RAM** | 16 GB | 32 GB+ recommended |
 
@@ -75,8 +75,19 @@ HF authentication. The profiler can auto-fetch these if you set:
 export HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
-You only need this if you plan to **profile** new models. Running
-pre-profiled simulations does not require an HF token.
+Running pre-profiled simulations never needs a token. You do need one
+for anything that touches the Hub:
+
+- **Profiling** a gated model, where the profiler auto-fetches its
+  `config.json` on first run.
+- **`bench run`**, which loads real weights — a much larger download
+  than a config file.
+- **`workloads.generators`**, which pulls the source dataset (and, with
+  `--use-vllm`, the model too).
+
+`scripts/docker-vllm.sh` forwards `HF_TOKEN` from your shell into the
+container and mounts `~/.cache/huggingface`, so a download is shared
+with the host and happens once.
 
 Get a token from [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens).
 

--- a/docs/docs/getting-started/installation/simulator.mdx
+++ b/docs/docs/getting-started/installation/simulator.mdx
@@ -7,8 +7,11 @@ title: Simulator setup
 
 The simulator runs in a Docker container based on
 [`astrasim/tutorial-micro2024`](https://hub.docker.com/r/astrasim/tutorial-micro2024).
-The container ships with the C++ ASTRA-Sim backend pre-built and
-provides a Python environment for the simulator.
+The image supplies Python 3.10 and ASTRA-Sim's **build** dependencies —
+it does **not** ship a pre-built backend for this repo's submodule, so
+step 3 below is required, not optional. It also ships none of the
+Python packages the simulator imports; `docker-sim.sh` pip-installs
+those at launch.
 
 This is the install path **everyone needs**. If you also want to
 profile new hardware or run end-to-end vLLM validation, follow
@@ -39,8 +42,19 @@ git submodule update --init --recursive
 This:
 
 - Mounts the repo root into the container at `/app/LLMServingSim`
-- Installs the Python deps the simulator needs (`pyyaml`,
-  `pyinstrument`, `rich`, `pandas`, `numpy`, `matplotlib`)
+- Installs the Python deps the simulator needs, three of them
+  **version-pinned** for the image's Python 3.10:
+
+  ```
+  pyyaml pyinstrument rich pandas==1.5.3 numpy==1.23.5 matplotlib==3.5.3
+  ```
+
+  Each is imported by code that runs in this container: `pyyaml` for
+  the profiler's `meta.yaml` and architecture catalogs, `pyinstrument`
+  by `serving/__main__.py`, `rich` by the loggers, `pandas` by the
+  scheduler / trace generator / PIM model, `numpy` by the scheduler,
+  and `matplotlib` by `bench/core/plots.py`. If you install by hand,
+  keep the pins.
 - Drops you into a `bash` shell at `/app/LLMServingSim`
 
 The container is named `servingsim_docker`. To re-attach later (e.g.,
@@ -73,17 +87,24 @@ What this does:
 - Compile the **analytical backend** of ASTRA-Sim
   (`astra-sim/build/astra_analytical/build.sh`).
 
-The build takes 2–5 minutes on a typical machine. When it finishes
-you should see:
+It runs `protoc` on Chakra's `et_def.proto` (once), then `cmake` and
+`cmake --build` with up to 16 threads. The build takes 2–5 minutes on a
+typical machine and prints ordinary cmake / make output — there is no
+success banner to look for. Check the artifact instead:
 
-```text
-Compilation finished successfully.
+```bash
+ls -l astra-sim/build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra
 ```
 
+That is the exact path `serving/__main__.py` launches as a subprocess,
+so if it exists and is executable, the build worked.
+
 :::tip ns3 backend
-The `compile.sh` script also has a commented-out block to build
-the ns3 backend (cycle-accurate network simulation). Most users
-don't need this. Uncomment it only if you set `--network-backend ns3`.
+`compile.sh` has a commented-out block for the ns3 backend
+(packet-level network simulation). Most users don't need it. Uncomment
+it only if you intend to pass `--network-backend ns3`, which launches a
+different binary:
+`astra-sim/extern/network_backend/ns-3/build/scratch/ns3.42-AstraSimNetwork-default`.
 :::
 
 ## 4. Verify the install
@@ -99,9 +120,10 @@ python -m serving \
   --log-interval 1.0
 ```
 
-You should see throughput logs scrolling once per second, and a
-final per-request CSV at `outputs/example_single_run.csv`. If you
-see a `[FileNotFoundError: profile_*.csv]` or similar, check
+You should see a startup banner, a **KV Cache Initialization** line, a
+heartbeat block once per simulated second, and a final per-request CSV
+at `outputs/example_single_run.csv`. If you instead get
+`FileNotFoundError: Profile variant folder not found: ...`, check
 [Troubleshooting → Missing profile data](../troubleshooting#missing-profile-data).
 
 

--- a/docs/docs/getting-started/installation/vllm.mdx
+++ b/docs/docs/getting-started/installation/vllm.mdx
@@ -28,6 +28,12 @@ hardware (RTXPRO6000), skip this page.
 The Docker path uses the official `vllm/vllm-openai:v0.19.0` image,
 which already contains vLLM, PyTorch, and all CUDA dependencies.
 
+That tag is built against **CUDA 12.x**. On a CUDA 13.x host, edit the
+image line in `scripts/docker-vllm.sh` to `vllm/vllm-openai:v0.19.0-cu130`
+instead. The pin matters beyond the driver: the profiler's MoE hook
+patches `FusedMoE.forward_native`, whose name is version-specific, so a
+different vLLM release can break profiling silently.
+
 ### 1. (Optional) Set HF_TOKEN
 
 Some model configs (Llama 3.x, gated Qwen variants) need a Hugging
@@ -122,8 +128,10 @@ You should see vLLM `0.19.0` and your GPU.
 
 **Bare-metal caveats**
 
-**CUDA driver mismatch** is the most common failure mode. vLLM 0.19.0
-needs a CUDA 13.x-compatible driver. Verify with `nvidia-smi`.
+**CUDA driver mismatch** is the most common failure mode. The
+`vllm==0.19.0` wheel `VLLM_USE_PRECOMPILED=1` fetches is built against
+CUDA 12.x — check your driver with `nvidia-smi` before assuming the
+prebuilt wheel fits.
 
 The `VLLM_USE_PRECOMPILED=1` flag tells `uv` to skip building vLLM
 from source. If your CUDA version doesn't match the prebuilt wheel,
@@ -140,6 +148,8 @@ Outside Docker you're responsible for `HF_TOKEN`,
 - **[Profiler guide](/docs/profiler/overview)**: capture per-layer
   CUDA kernel timings into the per-category CSV bundle the simulator
   consumes.
-- **[bench/](https://github.com/casys-kaist/LLMServingSim/tree/main/bench)**
-  on GitHub, run vLLM end-to-end and validate the simulator against
-  ground truth (TTFT / TPOT / throughput / running-waiting plots).
+- **[Bench CLI](/docs/reference/bench-cli)**: run vLLM end-to-end and
+  validate the simulator against ground truth, with every flag for both
+  subcommands.
+- **[Validation](/docs/validation)**: the accuracy numbers those runs
+  produced.

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -40,15 +40,17 @@ once per second. After the run finishes:
 head outputs/example_single_run.csv
 ```
 
-shows the per-request output (request id, prompt and decode tokens,
-TTFT, TPOT, end-to-end latency, …).
+shows the per-request output. The columns are `instance id`,
+`request id`, `model`, `input`, `output`, `arrival`, `end_time`,
+`latency`, `queuing_delay`, `TTFT`, `TPOT`, `ITL` — see
+**[Reading the output](/docs/simulator/reading-output)**.
 
 ## What the flags mean
 
 | Flag | What it does |
 | --- | --- |
 | `--cluster-config` | Cluster topology + hardware. Generates ASTRA-Sim input files automatically. |
-| `--dtype` | Model weight precision (`float16`, `bfloat16`, `float32`, `int8`). Picks the matching profile bundle. |
+| `--dtype` | Model weight precision (`float16`, `bfloat16`, `float32`, `fp8`, `int8`). Picks the matching profile bundle. Omit it and the model config's `torch_dtype` is used. |
 | `--block-size` | KV-cache block size in tokens. Default `16`. |
 | `--dataset` | JSONL file of requests (or agentic sessions). |
 | `--output` | Where to write per-request metrics. |

--- a/docs/docs/getting-started/troubleshooting.md
+++ b/docs/docs/getting-started/troubleshooting.md
@@ -168,18 +168,46 @@ Same idea for `vllm_docker`.
 combination that doesn't have profile data:
 
 ```text
-FileNotFoundError: ../profiler/perf/<hardware>/<model>/<variant>/tp1/dense.csv
+FileNotFoundError: Profile variant folder not found:
+../profiler/perf/RTXPRO6000/meta-llama/Llama-3.1-8B/bf16-kvfp8. Run the
+profiler with matching --dtype / --kv-cache-dtype, or pick an existing
+variant under ../profiler/perf/RTXPRO6000/meta-llama/Llama-3.1-8B
 ```
 
-**Cause:** The `(hardware, model, dtype, kv_cache_dtype)` tuple
-doesn't have a profiled CSV bundle.
+**Cause:** The `(hardware, model, dtype, kv_cache_dtype)` tuple has no
+profiled bundle. The check is on the **variant folder**, so the message
+names the directory rather than a specific CSV. `ls` the parent path it
+prints to see which variants you do have.
+
+Note that the variant is *derived*, not chosen: `--kv-cache-dtype fp8`
+appends `-kvfp8`, and `--dtype` (or the model config's `torch_dtype`
+when you omit it) supplies the prefix. So this fires when you flip a
+precision flag without a matching profile run, not only when the
+hardware is new.
+
+Two neighbouring errors with different fixes:
+
+```text
+FileNotFoundError: meta.yaml missing at <variant>/meta.yaml. Re-run the
+profiler to produce it.
+```
+
+The folder exists but the bundle is incomplete — usually a profile run
+that was interrupted.
+
+```text
+FileNotFoundError: Architecture yaml not found for model_type='gemma2'
+at profiler/models/gemma2.yaml. Add profiler/models/gemma2.yaml
+describing the architecture.
+```
+
+The model's family has no catalog yet. See
+**[Adding a model architecture](/docs/profiler/adding-model-architecture)**.
 
 **Fix:** either
 
-- pick a hardware / model combo that's already profiled
-  (see the
-  [Simulator → Reading the output](/docs/simulator/reading-output)
-  table), or
+- pick a hardware / model / precision combo that's already profiled
+  (`ls profiler/perf/`), or
 - run the **[Profiler](/docs/profiler/overview)** to generate the
   missing bundle yourself.
 
@@ -188,13 +216,28 @@ doesn't have a profiled CSV bundle.
 **Symptom:**
 
 ```text
-WARNING: runtime --max-num-batched-tokens (4096) exceeds profiled
-sweep bound (2048). Lookups will extrapolate.
+max-num-batched-tokens=4096 exceeds profiled 2048 for
+RTXPRO6000/meta-llama/Llama-3.1-8B/bf16; attention/dense lookups will
+extrapolate
 ```
 
-**Cause:** You're running the simulator with a token budget larger
-than the one the profiler swept. Latency lookups will linearly
-extrapolate past the measured range.
+There is a matching one for the sequence cap:
+
+```text
+max-num-seqs=256 exceeds profiled 128 for
+RTXPRO6000/meta-llama/Llama-3.1-8B/bf16; per-sequence lookups will
+extrapolate
+```
+
+**Cause:** You're running the simulator past the bounds the profiler
+swept, taken from `meta.yaml::engine_effective`. Latency lookups
+linearly extrapolate past the measured range.
+
+Both are emitted **once per `(hardware, model, variant)`**, not once per
+iteration, so seeing them a single time does not mean it happened only
+once. And they are silent when `meta.yaml` has no
+`engine_effective` entry for the field, so a hand-authored bundle gets
+no warning at all.
 
 **Fix:**
 

--- a/docs/docs/profiler/adding-hardware.md
+++ b/docs/docs/profiler/adding-hardware.md
@@ -160,41 +160,72 @@ runtime warnings work properly:
 ```yaml
 profiler_version: "synthetic-v1"
 vllm_version: "n/a"
-gpu: "<HARDWARE>"
+gpu: "<driver device name, or n/a>"
+hardware: "<HARDWARE>"          # must equal the folder name
+variant: "<VARIANT>"
+model: "<org>/<name>"
+tp_degrees: [1]
 profiled_at: "<date>"
 
 engine_effective:
   max_num_batched_tokens: <whatever your CSVs cover>
   max_num_seqs: <ditto>
-  dtype: bfloat16
-  kv_cache_dtype: auto
-
-attention_grid:
-  max_kv: <upper bound your attention.csv covers>
-  chunks: "<comma-separated chunk values>"
-  n_decode: "<comma-separated values>"
-  kv: "<comma-separated values>"
 
 skew_fit:
+  enabled: true                 # REQUIRED, see below
   per_tp:
     1:
       method: "synthetic-constant"
-      alpha_default: 0.3   # the pooled constant fallback
+      alpha_default: 0.3
 ```
 
-If you don't have skew measurements (most non-GPU paths won't),
-**omit** `skew.csv` and `skew_fit.csv` entirely. The simulator
-detects their absence and uses `alpha_default` from `meta.yaml` as a
-constant skew correction.
+`hardware` is the folder name a cluster config's `hardware` field must
+match; `gpu` is free-form provenance. They are separate fields — don't
+put the label in both.
+
+`engine_effective` takes only the two batching bounds; there is no
+`dtype` / `kv_cache_dtype` key there, since the dtypes are encoded in
+`variant`. Only those two are read, and only to emit the
+sweep-bound warning.
+
+`attention_grid` and `skew_profile` are provenance for humans and are
+**not read at run time**, so you can omit them from a synthetic bundle
+or fill them in however you like.
+
+:::danger `alpha_default` does nothing without `enabled: true`
+`_skew_alpha` returns the module fallback — which is **0**, i.e. no
+skew correction at all — unless `skew_fit.enabled` is truthy. So a
+bundle carrying `alpha_default: 0.3` but no `enabled` flag silently
+applies `alpha = 0`, not `0.3`. It also needs a `per_tp[<tp>]` entry
+for the TP being simulated; without one it falls back to a top-level
+`skew_fit.alpha_default` and then to 0.
+
+If you genuinely have no skew data, the honest choice is to leave
+`skew_fit` out entirely and accept `alpha = 0` (`t_mean`). A borrowed
+constant is not a safe default: the endpoint gap `(t_max - t_mean)` is
+a large fraction of an iteration, so alpha has to be known to about
+±0.02 to be worth applying at all.
+:::
+
+Omit `skew.csv` and `skew_fit.csv` when you have no
+heterogeneous-decode measurements.
 
 ### What you can skip
 
 - `skew.csv` and `skew_fit.csv` if you don't have heterogeneous-decode
-  data. Provide `alpha_default` in `meta.yaml::skew_fit.per_tp.<TP>`.
+  data — see the warning above about what that costs you.
 - `moe.csv` if you're not modeling MoE on this hardware (only needed
   when running MoE models).
-- TP=N folders for TP degrees you don't need to simulate. The
-  simulator only loads the TPs your cluster config asks for.
+- `tp<N>/` folders for TP degrees you don't need to simulate. Note the
+  mechanism: `_load_perf_db` loads **every** `tp*/` folder it finds and
+  then checks that the ones your cluster config needs are among them.
+  A missing one is a hard error, not a fallback:
+
+  ```text
+  FileNotFoundError: No profile data for tp=[4] under
+  perf/<hw>/<model>/<variant>/. Re-run the profiler with TP_DEGREES
+  including 4.
+  ```
 
 ### What you cannot skip
 

--- a/docs/docs/profiler/output-bundle.md
+++ b/docs/docs/profiler/output-bundle.md
@@ -46,10 +46,11 @@ remember to use μs.
 
 ```
 layer,tokens,time_us
-qkv_proj,128,42.3
-qkv_proj,256,79.4
-qkv_proj,512,154.2
-o_proj,128,38.1
+act_fn,1,4.21367
+act_fn,2,5.36533
+...
+qkv_proj,1,20.4373
+qkv_proj,2,20.4813
 ...
 ```
 
@@ -71,10 +72,10 @@ Layers it covers: `embedding`, `layernorm`, `qkv_proj`, `qk_norm`,
 
 ```
 layer,sequences,time_us
-lm_head,1,18.4
-lm_head,4,72.1
-lm_head,16,289.2
-sampler,1,6.7
+lm_head,1,1075.13
+lm_head,2,1044.52
+...
+sampler,1,25.9333
 ...
 ```
 
@@ -93,11 +94,10 @@ kernel shapes:
 
 ```
 prefill_chunk,kv_prefill,n_decode,kv_decode,time_us
-0,0,1,128,12.4
-0,0,1,256,18.7
-0,0,4,128,32.1
-512,2048,0,0,184.3
-512,2048,4,128,221.6
+0,0,1,16,8.08533
+0,0,1,32,8.17033
+...
+512,2048,4,128,...
 ...
 ```
 
@@ -121,10 +121,8 @@ densify; larger values speed up profiling at some accuracy cost.
 
 ```
 tokens,activated_experts,time_us
-1,8,4.2
-4,8,12.8
-8,8,21.4
-1,16,7.1
+1,8,50.2297
+2,8,56.1917
 ...
 ```
 
@@ -145,7 +143,8 @@ Raw heterogeneous-decode shots:
 
 ```
 regime,n,nb,ratio,skew,pc,kp,kvs,kv_big,kv_mean,t_mean_us,t_max_us,t_skew_us,alpha
-mixed,8,1,0.125,4.0,512,2048,512,2048,704,38.2,52.1,40.8,0.187
+pure,4,1,0.25,4.0,0,0,512,2048,896,74.784,118.88,74.657,-0.0029
+pure,4,1,0.25,4.0,0,0,2048,8192,3584,169.854,321.566,171.394,0.0102
 ...
 ```
 
@@ -167,7 +166,7 @@ three measurements:
 | `t_mean_us` | Latency at all-decodes-uniform-at-mean kv |
 | `t_max_us` | Latency at all-decodes-uniform-at-max kv |
 | `t_skew_us` | Latency at the actual bimodal mix |
-| `alpha` | `(t_skew - t_mean) / (t_max - t_mean)` ∈ [0, 1] |
+| `alpha` | `(t_skew - t_mean) / (t_max - t_mean)`. **Not clamped** — 14-20% of rows are negative and 2-5% exceed 1, as the sample rows above show. `nan` when `t_max <= t_mean`, and the fit drops those |
 
 Methodology: **[Skew & alpha fit](./skew-alpha-fit)**.
 
@@ -178,9 +177,8 @@ at run time:
 
 ```
 pc,n_label,skew_rate_label,kv_big_label,kp_label,alpha,n_samples
-0,n_8,sr_low,kvb_4096,kp_0,0.21,17
-0,n_8,sr_low,kvb_4096,kp_2048,0.24,12
-512,n_8,sr_high,kvb_8192,kp_2048,0.62,9
+0,n<=128,sr<=15%,kvB<=16k,kp=0,0.0322,4
+0,n<=128,sr<=15%,kvB<=1k,kp=0,0.0323,4
 ...
 ```
 
@@ -188,87 +186,161 @@ pc,n_label,skew_rate_label,kv_big_label,kp_label,alpha,n_samples
 | --- | --- |
 | `pc` | Prefill chunk bucket (raw value) |
 | `n_label` | `n_decode` bucket label |
-| `skew_rate_label` | Skew-rate bucket label (normalized [0, 1] scheme) |
+| `skew_rate_label` | Skew-rate bucket label. The rate itself *is* clipped to [0, 1], unlike alpha — fixed bins `sr<=5%` / `sr<=15%` / `sr<=40%` / `sr<=70%` / `sr>70%` |
 | `kv_big_label` | Big-KV bucket (log-4× bins) |
 | `kp_label` | `kv_prefill` bucket label |
 | `alpha` | Fitted weighted-LS alpha for this bucket |
 | `n_samples` | Number of `skew.csv` rows that contributed |
 
-Bucket axis definitions live in `meta.yaml::skew_fit.bucket_axes`,
-so widening the profile sweep automatically lights up finer
-resolution without any simulator code change.
+Labels are the human-readable comparison strings the fitter emits
+(`n<=128`, `kvB<=4k`, `kp=0`), not slugs — the simulator rebuilds them
+from `meta.yaml::skew_fit.bucket_axes` and joins them into the key
+`pc={pc}|{n_label}|{sr_label}|{kvb_label}|{kp_label}`, so they have to
+match character for character.
+
+Because the axes are recorded in the meta rather than hardcoded,
+widening the profile sweep lights up finer resolution with no
+simulator-side change: `n` and `kp` get one bin per unique profiled
+value, and `kv_big` extends its log-4x bins to the observed maximum.
 
 ## `meta.yaml`
 
-Sibling of the `tp<N>/` folders. Three groups of metadata:
+Sibling of the `tp<N>/` folders. Below is a real one, from
+`profiler/perf/RTXPRO6000/Qwen/Qwen3-32B/bf16/`, with the per-TP fit
+block trimmed to one entry:
 
 ```yaml
-profiler_version: ...
+profiler_version: 1.0.0
 vllm_version: 0.19.0
-gpu: "RTXPRO6000"
-profiled_at: "2026-04-30T14:23:11Z"
-
+cuda_version: '13.0'
+gpu: NVIDIA RTX PRO 6000 Blackwell Server Edition
+hardware: RTXPRO6000
+profiled_at: '2026-04-24T12:35:08+00:00'
+architecture: qwen3
+architecture_sha256: c0557f326f38c70b46b5841c90d3447863d653dc9a228019db74eec591c2bf78
+model: Qwen/Qwen3-32B
+variant: bf16
+tp_degrees: [1, 2]
 engine_effective:
+  load_format: dummy
+  enforce_eager: true
+  skip_tokenizer_init: true
+  enable_prefix_caching: false
+  generation_config: vllm
+  tensor_parallel_size: 1
+  block_size: 16
+  gpu_memory_utilization: 0.9
   max_num_batched_tokens: 2048
   max_num_seqs: 256
-  dtype: bfloat16
-  kv_cache_dtype: auto
-
+  hf_overrides:
+    num_hidden_layers: 1
+    intermediate_size: 12800
+    num_attention_heads: 32
+    num_key_value_heads: 4
+    vocab_size: 75968
+  worker_extension_cls: profiler.hooks.extension.Extension
+  model: /tmp/profiler_model_dnlix5xf
 attention_grid:
   max_kv: 16384
   chunk_factor: 2.0
   kv_factor: 2.0
-  chunks: "0, 32, 64, 128, 256, 512, 1024, 2048"
-  n_decode: "0, 1, 2, 4, 8, 16, 32, 64, 128, 256"
-  kv: "0, 32, 64, ..., 16384"
-
+  chunks: 0, 16-2048 x2
+  n_decode: 0, 1-256 x2
+  kv: 0, 16-16384 x2
+measurement_iterations: 3
 skew_profile:
-  factors:
-    n: 2.0
-    pc: 2.0
-    kp: 2.0
-    kvs: 2.0
+  enabled: true
+  factors: {n: 2.0, pc: 2.0, kp: 2.0, kvs: 2.0}
   grid:
-    n: "..."
-    ratio: "..."
-    pc: "..."
-    kp: "..."
-    kvs: "..."
-    skew: "1.5, 2.0, 4.0, 8.0, 16.0"
-
+    n: 2-256 x2
+    ratio: [0.0625, 0.125, 0.25, 0.5, 0.75, 0.9]
+    pc: 0, 16-2048 x2
+    kp: 0, 512-8192 x2
+    kvs: 128-16384 x2
+    skew_rep: 4.0
 skew_fit:
+  enabled: true
   bucket_axes:
-    n_label: ["n_2", "n_4", "n_8", "n_16", "n_32", "n_overflow"]
-    skew_rate_label: ["sr_low", "sr_mid", "sr_high"]
-    kv_big_label: ["kvb_1024", "kvb_4096", "kvb_16384", "kvb_overflow"]
-    kp_label: ["kp_0", "kp_2048", "kp_8192", "kp_overflow"]
+    pc: raw pc value (profiled grid point)
+    n_bins: [0, 2, 4, 8, 16, 32, 64, 128, 256, 1000000]
+    n_labels: [n<=2, n<=4, n<=8, n<=16, n<=32, n<=64, n<=128, n<=256, n>256]
+    skew_rate_bins: [-0.01, 0.05, 0.15, 0.4, 0.7, 1.01]
+    skew_rate_labels: [sr<=5%, sr<=15%, sr<=40%, sr<=70%, sr>70%]
+    kv_big_bins: [0, 1024, 4096, 16384, 1000000000]
+    kv_big_labels: [kvB<=1k, kvB<=4k, kvB<=16k, kvB>16k]
+    kp_bins: [-1, 0, 512, 1024, 2048, 4096, 8192, 1000000000]
+    kp_labels: [kp=0, kp<=512, kp<=1k, kp<=2k, kp<=4k, kp<=8k, kp>8k]
   per_tp:
     1:
-      method: weighted_ls
-      n_samples: 13247
-      alpha_default: 0.34
-      rel_err_p50: 0.027
-      rel_err_p90: 0.148
-      rel_err_p99: 0.31
-      signed_mean: 0.004
-      bucket_table: "tp1/skew_fit.csv"
-    2:
-      ...
+      method: per_bucket_wls_5axis
+      n_samples: 13016
+      alpha_default: 0.057
+      bucket_table: tp1/skew_fit.csv
+      rel_err_p50: 0.0121
+      rel_err_p90: 0.0609
+      rel_err_p99: 0.3578
+      signed_mean: 0.005
 ```
 
-The simulator reads:
+### Identity and provenance
 
-- `engine_effective`: to warn when runtime values exceed profiled
-  bounds (lookups will extrapolate).
-- `skew_fit.bucket_axes`: to build the bucket key at run time.
-- `skew_fit.per_tp[tp].alpha_default`: fallback when a request's
-  bucket isn't in `skew_fit.csv`.
-- `attention_grid` and `skew_profile` are informational (not
-  consumed by the simulator).
+| Key | Meaning |
+| --- | --- |
+| `profiler_version` / `vllm_version` / `cuda_version` | Versions the bundle was produced with. Kernel timings shift a few percent across CUDA driver versions, so this is the field to check before trusting a mixed comparison |
+| `gpu` | The **driver's** device name, verbatim |
+| `hardware` | The `--hardware` label, i.e. the folder name and the value a cluster config's `hardware` field must match. Distinct from `gpu` |
+| `architecture` / `architecture_sha256` | Which `profiler/models/*.yaml` was used, and its hash — so you can tell whether a catalog edit invalidates the bundle |
+| `model` / `variant` / `tp_degrees` | What was profiled |
+| `measurement_iterations` | Timed forwards averaged per shot |
 
-Full bucket → α mapping lives in `tp<N>/skew_fit.csv`. The simulator
-hydrates the CSV into an in-memory `alpha_by_bucket` map on first
-load.
+### `engine_effective`
+
+The engine kwargs vLLM actually ran with, not what was requested.
+Notable entries:
+
+- `max_num_batched_tokens` / `max_num_seqs` — the **logical** values.
+  The engine is booted with `max_num_batched_tokens + max_num_seqs` for
+  shot-bypass headroom, and the bump is subtracted back before
+  recording, so what you see here is the sweep bound.
+- `hf_overrides` — how single-GPU TP emulation is done: per-rank shapes
+  divided by the TP degree, plus `num_hidden_layers: 1` since one block
+  is enough to time a layer.
+- `load_format: dummy` — weights are never loaded; only shapes matter.
+- `model` — the tmpdir the model config was written to, so vLLM needed
+  no Hub access. The path is dead after the run.
+
+There is no `dtype` or `kv_cache_dtype` key here. The effective dtypes
+are encoded in `variant`.
+
+### Grid specs are compact, not enumerated
+
+`attention_grid` and `skew_profile.grid` use a shorthand rather than
+listing every point:
+
+| Spec | Reads as |
+| --- | --- |
+| `0, 16-2048 x2` | the value `0`, then `16` doubling to `2048` |
+| `2-256 x2` | `2` doubling to `256`, no zero point |
+| `[0.0625, 0.125, …]` | an explicit list, used where the axis is not geometric |
+
+`skew_profile.grid.skew_rep` is the single representative skew factor
+Tier 1 fires at (`4.0`); the Tier 2 anchor sweep's skew values are not
+recorded here.
+
+### What the simulator actually reads
+
+| Key | Used for |
+| --- | --- |
+| `engine_effective.max_num_batched_tokens` / `.max_num_seqs` | One-shot warning when the runtime CLI exceeds the sweep bounds, since lookups will extrapolate |
+| `skew_fit.enabled` | Whether to apply any skew correction at all |
+| `skew_fit.bucket_axes` | Building the bucket key per batch. Falls back to module defaults for bundles written before these were recorded |
+| `skew_fit.per_tp[tp].alpha_by_bucket` or `.bucket_table` | The alpha table, hydrated from `tp<N>/skew_fit.csv` when the meta points at a CSV |
+| `skew_fit.per_tp[tp].alpha_default` | Fallback for a bucket absent from the table |
+
+Everything else — versions, `gpu`, `architecture_sha256`,
+`attention_grid`, `skew_profile`, and the `rel_err_*` / `signed_mean`
+fit diagnostics — is provenance for humans and is not consumed at run
+time.
 
 ## How the simulator consumes this
 

--- a/docs/docs/profiler/overview.mdx
+++ b/docs/docs/profiler/overview.mdx
@@ -65,12 +65,26 @@ container** (`astrasim/tutorial-micro2024`). They share the
 
 ## Bundled profile data
 
-| Hardware | Models profiled | Variants |
-| --- | --- | --- |
-| `RTXPRO6000` | `meta-llama/Llama-3.1-8B`, `Qwen/Qwen3-32B`, `Qwen/Qwen3-30B-A3B-Instruct-2507` | `bf16`, `bf16-kvfp8` |
+| Hardware | Model | Variant | TP degrees |
+| --- | --- | --- | --- |
+| `RTXPRO6000` | `meta-llama/Llama-3.1-8B` | `bf16` | 1, 2 |
+| `RTXPRO6000` | `Qwen/Qwen3-32B` | `bf16` | 1, 2 |
+| `RTXPRO6000` | `Qwen/Qwen3-30B-A3B-Instruct-2507` | `bf16` | 1, 2 |
 
-If your `(hardware, model, variant)` combo is in this table, you can
-skip the profiler entirely.
+That is the whole set: one hardware target, three models, **`bf16`
+only**, TP=1 and TP=2. If your `(hardware, model, variant, tp)` combo is
+in this table you can skip the profiler entirely; anything else needs a
+profile run.
+
+Two consequences that catch people out:
+
+- **No `-kvfp8` bundle ships.** `--kv-cache-dtype fp8` resolves to a
+  `bf16-kvfp8` variant folder that does not exist, so it fails at
+  startup until you profile it with `KV_CACHE_DTYPE=fp8`. See
+  **[Examples → FP8 KV cache](/docs/examples/memory-tiers/fp8-kv-cache)**.
+- **TP=4 and above need a profile run**, even on RTXPRO6000 with a
+  bundled model. `_load_perf_db` hard-errors on a missing `tp<N>/`
+  folder rather than extrapolating from TP=2.
 
 ## Prerequisites
 

--- a/docs/docs/profiler/running.md
+++ b/docs/docs/profiler/running.md
@@ -37,7 +37,7 @@ doesn't.
 2. Picks the matching architecture YAML by `model_type`.
 3. Writes the model config to a tmpdir; spins vLLM up against that.
 4. Sweeps **dense / per_sequence / attention / moe** shot grids,
-   writing CSVs under `perf/<HW>/<MODEL>/<variant>/tp<N>/`.
+   writing CSVs under `profiler/perf/<HW>/<MODEL>/<variant>/tp<N>/`.
 5. (If `SKIP_SKEW=0`, the default) Runs the heterogeneous-decode
    skew sweep and fits per-bucket alphas to `skew_fit.csv`.
 6. Writes `meta.yaml` summarizing the run.
@@ -51,13 +51,13 @@ on a single GPU by dividing the model's per-rank shapes via
 | Variable | Meaning |
 | --- | --- |
 | `MODEL` | HF-style `<org>/<name>`. Must have a config at `configs/model/<MODEL>.json` (auto-downloaded on first run) |
-| `HARDWARE` | Free-form label that becomes the folder name under `perf/`. Pick something meaningful (e.g., `RTXPRO6000`, `H100`, `MI300X`) |
+| `HARDWARE` | Free-form label that becomes the folder name under `profiler/perf/`. Pick something meaningful (e.g., `RTXPRO6000`, `H100`, `MI300X`) |
 
 ## Sweep shape
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `TP_DEGREES` | `1,2,4` | Comma-separated TP degrees. **Must include `1`** (TP-stable layers are profiled once at TP=1 and replicated to other TP folders) |
+| `TP_DEGREES` | `1,2` in `profile.sh` (`--tp` defaults to `1`) | Comma-separated TP degrees. **Must include `1`** (TP-stable layers are profiled once at TP=1 and replicated to other TP folders) |
 | `MAX_NUM_BATCHED_TOKENS` | `2048` | Profiler internally bumps this by `+MSQ` for shot-bypass headroom; subtracted back when recording meta |
 | `MAX_NUM_SEQS` | `256` | Profile with `MSQ > runtime MSQ` so mixed-regime cases at `n = runtime_MSQ` stay feasible |
 
@@ -147,6 +147,89 @@ VERBOSITY="--silent"        # warnings only
 VERBOSITY="--verbose"       # DEBUG + vLLM stdout
 VERBOSITY=""                # default (INFO)
 ```
+
+## Calling `python -m profiler` directly
+
+`profile.sh` is a convenience wrapper; every variable in it maps to a
+flag. Call the module yourself when you want to script a sweep, or for
+the `slice` subcommand, which `profile.sh` does not expose at all.
+
+```bash
+python -m profiler profile <model> --hardware <hw> [options]
+python -m profiler slice   <model> --hardware <hw> --tp-refresh N --group G [options]
+```
+
+`<model>` is an HF-style `<org>/<name>` resolving to
+`configs/model/<org>/<name>.json`, or an explicit path ending in
+`.json`. HF-style ids are auto-downloaded from the Hub on first use
+(honouring `HF_TOKEN`); explicit paths are never fetched, so a missing
+file is an error.
+
+### Flags shared by both subcommands
+
+| Flag | Default | `profile.sh` variable |
+| --- | --- | --- |
+| `--hardware` | **required** | `HARDWARE` |
+| `--tp` | `1` | `TP_DEGREES` |
+| `--variant` | auto-derived from dtypes | `VARIANT` |
+| `--dtype` | vLLM default (model's `torch_dtype`) | `DTYPE` |
+| `--kv-cache-dtype` | `auto` | `KV_CACHE_DTYPE` |
+| `--max-num-batched-tokens` | `2048` | `MAX_NUM_BATCHED_TOKENS` |
+| `--max-num-seqs` | `256` | `MAX_NUM_SEQS` |
+| `--attention-max-kv` | `16384` | `ATTENTION_MAX_KV` |
+| `--attention-chunk-factor` | `2.0` | `ATTENTION_CHUNK_FACTOR` |
+| `--attention-kv-factor` | `2.0` | `ATTENTION_KV_FACTOR` |
+| `--measurement-iterations` | `3` | `MEASUREMENT_ITERATIONS` |
+| `--skip-skew` | off | `SKIP_SKEW=1` |
+| `--only-skew` | off | `ONLY_SKEW=1` |
+| `--skew-n-factor` | `2.0` | `SKEW_N_FACTOR` |
+| `--skew-pc-factor` | `2.0` | `SKEW_PC_FACTOR` |
+| `--skew-kp-factor` | `2.0` | `SKEW_KP_FACTOR` |
+| `--skew-kvs-factor` | `2.0` | `SKEW_KVS_FACTOR` |
+| `--force` | off (resume) | `FORCE=1` |
+| `--out-root` | `profiler/perf` | — |
+| `--model-config-root` | `configs/model` | — |
+| `--log-level` | `INFO` | `VERBOSITY` |
+| `--silent` | — | `VERBOSITY="--silent"` |
+| `--verbose` | — | `VERBOSITY="--verbose"` |
+
+`--out-root` and `--model-config-root` have no `profile.sh` equivalent.
+Use `--out-root` to write a bundle somewhere other than
+`profiler/perf/`, and `--model-config-root` to point at a different
+tree of HF configs — useful for profiling hypothetical shapes without
+adding them to the repo.
+
+`--log-level`, `--silent`, and `--verbose` are mutually exclusive.
+`--silent` is `WARNING`, `--verbose` is `DEBUG` **plus** vLLM's own
+stdout, and `--log-level` overrides either explicitly.
+
+`--tp` must include `1`: TP-stable layers (layernorms, sampler) are
+profiled once at TP=1 and replicated into the other `tp<N>/` folders by
+the writer, so a sweep without TP=1 has nothing to replicate from.
+
+### `slice`: refresh one (tp, category) pair
+
+After a full sweep, iterate on a single category without redoing the
+rest:
+
+```bash
+python -m profiler slice meta-llama/Llama-3.1-8B \
+    --hardware RTXPRO6000 --tp-refresh 1 --group attention
+```
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--tp-refresh` | ✓ | The single TP degree to refresh. Must be a member of `--tp` |
+| `--group` | ✓ | One of `dense`, `per_sequence`, `attention`, `moe` |
+
+It boots one engine at that TP, fires only that category's grid, and
+rewrites `tp<N>/<group>.csv` plus `meta.yaml`. Errors out if the
+architecture YAML has no entries in `catalog.<group>` — asking for
+`moe` on a dense model, for instance.
+
+Note `slice` handles only the four uniform categories. The skew sweep
+is not a `--group` value; refresh it with
+`python -m profiler profile ... --only-skew` instead.
 
 ## Multi-model batch sweep: `profile-all.sh`
 

--- a/docs/docs/profiler/skew-alpha-fit.md
+++ b/docs/docs/profiler/skew-alpha-fit.md
@@ -49,14 +49,50 @@ the same shapes. Three numbers per shot:
 From these three:
 
 ```
-alpha = (t_skew - t_mean) / (t_max - t_mean)   ∈ [0, 1]
+alpha = (t_skew - t_mean) / (t_max - t_mean)
 ```
 
 Alpha is a **normalized position on the t_mean → t_max line**:
 
 - `alpha = 0` → no penalty; skewed batch behaves like uniform-mean.
 - `alpha = 1` → full penalty; skewed batch behaves like uniform-max.
-- typical values: 0.2–0.5.
+
+`t_max > t_mean` is required, else the row is recorded as `nan` and the
+fit skips it.
+
+:::info Alpha is not clamped to [0, 1]
+The name says "normalized", but nothing bounds the ratio, and the
+measured data lands outside `[0, 1]` regularly. Across the six bundles
+in `profiler/perf/`, per `skew.csv`:
+
+| | range |
+| --- | --- |
+| p50 | 0.07 – 0.13 |
+| p90 | 0.46 – 0.96 |
+| rows with `alpha < 0` | 14 – 20 % |
+| rows with `alpha > 1` | 2 – 5 % |
+
+The two tails have different causes, and only one is noise:
+
+- **`alpha < 0`** is mostly the endpoint gap sitting inside
+  measurement noise. A shot with `t_mean = 941.7 us` and
+  `t_max = 946.6 us` has a 4.9 us gap on a ~940 us baseline, so a
+  `t_skew` 10 us below `t_mean` reads as `alpha = -2.16`. The
+  magnitude is an artifact of dividing by a small number; the
+  underlying signal is "no measurable penalty".
+- **`alpha > 1` is real.** A skewed mix can genuinely cost more than
+  *either* uniform reference, because tile padding and SM imbalance
+  are not bounded by the uniform-max case. The largest row in the
+  Qwen3-32B TP=1 bundle is `n=32, pc=2048, kv_big=16384, kvs=4096`
+  at `t_mean = 19.1 ms`, `t_max = 19.3 ms`, `t_skew = 24.5 ms` -
+  5.2 ms above uniform-max, so `alpha = 19.4`.
+
+Neither the fit nor `_skew_alpha` clips the value, so a bucket
+resolving to a large alpha extrapolates past `t_max` by design. The
+per-bucket weighted-LS fit is what keeps the noise tail from
+dominating: it pools many shots per cell, so isolated `-2.16` rows are
+averaged against their neighbours rather than used directly.
+:::
 
 At simulation time, the lookup becomes:
 
@@ -131,10 +167,18 @@ runs a weighted least-squares fit per bucket.
 | Axis | Bucket scheme |
 | --- | --- |
 | `pc` | One bucket per unique `pc` value (raw) |
-| `n_label` | One bucket per unique `n` value (`n=0` sentinel + overflow) |
-| `skew_rate_label` | Fixed normalized [0, 1] scheme, `sr_low`, `sr_mid`, `sr_high` |
-| `kv_big_label` | log-4× bins extended to observed max, `kvb_1024`, `kvb_4096`, `kvb_16384`, `kvb_overflow` |
-| `kp_label` | One bucket per unique `kp` value + overflow |
+| `n_label` | One bucket per profiled `n` value, plus an overflow bucket: `n<=2`, `n<=4`, `n<=8`, `n<=16`, `n<=32`, `n<=64`, `n<=128`, `n<=256`, `n>256` |
+| `skew_rate_label` | Fixed bins on the normalized [0, 1] rate — the one axis that really is clipped to that range: `sr<=5%`, `sr<=15%`, `sr<=40%`, `sr<=70%`, `sr>70%` |
+| `kv_big_label` | log-4x bins extended to the observed max: `kvB<=1k`, `kvB<=4k`, `kvB<=16k`, `kvB>16k` |
+| `kp_label` | One bucket per profiled `kp` value, with a `kp=0` sentinel for pure-decode batches and an overflow bucket: `kp=0`, `kp<=512`, `kp<=1k`, `kp<=2k`, `kp<=4k`, `kp<=8k`, `kp>8k` |
+
+These are the **literal strings** the fitter writes and the simulator
+rebuilds, joined into `pc={pc}|{n_label}|{sr_label}|{kvb_label}|{kp_label}`,
+so they have to match character for character. The values above are from
+the Qwen3-32B bf16 bundle; a wider sweep produces more `n` and `kp`
+buckets and extends the `kv_big` bins, which is why the simulator reads
+them out of `meta.yaml::skew_fit.bucket_axes` rather than hardcoding
+them.
 
 The bucket axis definitions are written to
 `meta.yaml::skew_fit.bucket_axes` so the simulator builds the same

--- a/docs/docs/reference/bench-cli.md
+++ b/docs/docs/reference/bench-cli.md
@@ -1,0 +1,235 @@
+---
+sidebar_position: 5
+title: Bench CLI
+---
+
+# `python -m bench` CLI flags
+
+Complete reference for the vLLM benchmark harness. `bench` has two
+subcommands: `run` replays a workload through real vLLM, `validate`
+compares a finished run against simulator output.
+
+Both must run inside the **vLLM container**
+(`scripts/docker-vllm.sh`), not the simulator container. See
+**[Installation → vLLM environment](/docs/getting-started/installation/vllm)**.
+
+For the resulting accuracy numbers, see
+**[Validation](/docs/validation)**.
+
+## `python -m bench run`
+
+Strict replay: the runner reads a LLMServingSim-format JSONL workload
+— the same format `python -m workloads.generators` emits and
+`python -m serving --dataset` consumes — and pins every request's
+`input_tok_ids` and `output_toks` via
+`SamplingParams(min_tokens=N, max_tokens=N, ignore_eos=True)`. The
+vLLM run therefore processes exactly the prompts the simulator sees,
+in the same order.
+
+### Required
+
+| Flag | Type | Description |
+| --- | --- | --- |
+| `--model` | string | HF model id, passed verbatim to `vllm.AsyncLLM`. Unlike the simulator, this is a real load: weights are downloaded and placed on GPU |
+| `--dataset` | path | LLMServingSim-format JSONL workload. See **[Workloads → JSONL format](/docs/workloads/jsonl-format)** |
+| `--output-dir` | path | Where to write `meta.json` / `requests.jsonl` / `timeseries.csv`. Conventionally `bench/results/<run_id>/` |
+
+### Parallelism
+
+These are vLLM's own engine arguments, forwarded unchanged. They are
+the bench-side counterpart of a cluster config's `tp_size` / `ep_size`
+/ `dp_group`.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--tensor-parallel-size` | int | `1` | vLLM `tensor_parallel_size` |
+| `--data-parallel-size` | int | `1` | vLLM `data_parallel_size` (DP across engines) |
+| `--enable-expert-parallel` | flag | off | vLLM `enable_expert_parallel`, for MoE models |
+
+### Scheduler and precision
+
+Match these to the simulator run you intend to compare against, or the
+comparison is not apples-to-apples.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--max-num-seqs` | int | `128` | vLLM `max_num_seqs`, the per-engine running cap |
+| `--max-num-batched-tokens` | int | `2048` | vLLM `max_num_batched_tokens` |
+| `--max-model-len` | int | `None` | vLLM `max_model_len`. `None` uses the model's own maximum |
+| `--dtype` | string | `bfloat16` | Model dtype |
+| `--kv-cache-dtype` | string | `auto` | vLLM `kv_cache_dtype` |
+| `--seed` | int | `42` | Sampling seed |
+
+:::note Defaults differ from `python -m serving`
+`bench run` defaults `--dtype` to `bfloat16` outright, where the
+simulator resolves it from the model config's `torch_dtype`. `bench`
+also has no `--block-size`: vLLM picks the KV block size itself, and
+the value it settled on is recorded in `meta.json` under
+`kv_cache.block_size`. Read it back and pass it to the simulator as
+`--block-size` if you want the two to line up.
+:::
+
+### Workload and output
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--num-reqs` | int | `0` | Cap on requests taken from the dataset. `0` = replay all |
+| `--tick-seconds` | float | `1.0` | Stat-logger downsample interval, i.e. row spacing in `timeseries.csv`. Matches the simulator's `--log-interval` |
+| `--log-level` | choice | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` |
+
+### Output
+
+```
+<output-dir>/
+  meta.json          run metadata plus what vLLM *resolved*: kv_cache
+                     (num_gpu_blocks, block_size, num_kv_tokens,
+                     gpu_memory_utilization), hardware (device name,
+                     total memory, CUDA / torch versions), and
+                     resolved_config -- the whole VllmConfig, one key
+                     per sub-config
+  requests.jsonl     per request: request_id, input_toks, output_toks,
+                     arrival_time, queued_ts, scheduled_ts,
+                     first_token_ts, last_token_ts
+  timeseries.csv     per tick: t, prompt_throughput, gen_throughput,
+                     running, waiting, kv_cache_pct
+```
+
+`meta.json`'s `kv_cache.num_gpu_blocks` is the number worth reading
+first: it is the KV capacity the simulator has to match, and the only
+place vLLM's activation peak shows up, since the rest of its memory
+budget is known up front. The simulator does not model that peak, so
+its capacity at the same `mem_util` is an upper bound. See
+**[KV cache and memory](/docs/simulator/scheduling/kv-cache-and-memory)**.
+
+The dataset is never modified — generation lives in
+`workloads/generators`.
+
+## `python -m bench validate`
+
+Loads the bench artifacts plus the simulator's per-request CSV and log
+for the same workload, derives TTFT / TPOT / end-to-end latency on both
+sides under matched definitions, and writes plots and a numeric summary
+into a subdirectory of the bench run.
+
+### Required
+
+| Flag | Type | Description |
+| --- | --- | --- |
+| `--bench-dir` | path | A finished `bench run` output directory |
+| `--sim-csv` | path | Simulator per-request CSV, i.e. whatever you passed to `python -m serving --output` |
+| `--sim-log` | path | Simulator log, parsed for per-tick running / waiting counts. Capture it by redirecting the simulator's stdout |
+
+### Optional
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--output-subdir` | string | `validation` | Subdirectory under `--bench-dir` for plots and summary |
+| `--prefix` | string | `""` | Filename prefix for the generated files |
+| `--title` | string | `vLLM vs LLMServingSim` | Plot title suffix |
+| `--log-level` | choice | `INFO` | `DEBUG` / `INFO` / `WARNING` / `ERROR` |
+
+### Output
+
+```
+<bench-dir>/<output-subdir>/
+  <prefix>_throughput.png     prompt + generation throughput, both sides
+  <prefix>_requests.png       running / waiting counts over time
+  <prefix>_latency.png        TTFT / TPOT / latency CDFs
+  <prefix>_summary.txt        mean and P50 / P90 / P95 / P99 per metric, with diff%
+```
+
+### Matched metric definitions
+
+Both sides compute the same three quantities from the same reference
+points, so `diff%` is meaningful:
+
+| Metric | Definition |
+| --- | --- |
+| TTFT | `first_token_ts - arrival_time` (queueing included) |
+| TPOT | `(last_token_ts - first_token_ts) / max(1, output_toks - 1)` |
+| Latency | `last_token_ts - arrival_time` |
+
+The simulator's CSV exposes `arrival`, `end_time`, and a per-token ITL
+list directly; bench derives the same fields from vLLM's
+`RequestStateStats`.
+
+:::caution `prompt_throughput` is not comparable tick-for-tick
+vLLM counts a prompt once, at prefill completion, so its
+`prompt_throughput` series cannot show preemption and recomputation.
+The simulator's per-tick prompt tokens can. Compare the per-request
+metrics above, and read the throughput plots as shape rather than as
+matched values.
+:::
+
+## Shell wrappers
+
+Two host-side wrappers set the flags for you. Both are meant to be
+edited in place or driven by environment variables.
+
+### `bench/bench.sh`
+
+Every knob is an environment variable with a default:
+
+```bash
+MODEL=Qwen/Qwen3-32B \
+DATASET=workloads/sharegpt-qwen3-32b-300-sps10.jsonl \
+TP=2 DP=1 EXPERT_PARALLEL=0 \
+MAX_NUM_SEQS=128 MAX_NUM_BATCHED_TOKENS=2048 \
+./bench/bench.sh
+```
+
+| Variable | Flag it sets | Default |
+| --- | --- | --- |
+| `MODEL` | `--model` | `Qwen/Qwen3-32B` |
+| `DATASET` | `--dataset` | `workloads/sharegpt-qwen3-32b-300-sps10.jsonl` |
+| `RUN_ID` | (names the output dir) | `$(date +%Y%m%d-%H%M%S)` |
+| `OUTPUT_DIR` | `--output-dir` | `bench/results/$RUN_ID` |
+| `TP` | `--tensor-parallel-size` | `2` |
+| `DP` | `--data-parallel-size` | `1` |
+| `EXPERT_PARALLEL` | `--enable-expert-parallel` when `1` | `0` |
+| `MAX_NUM_SEQS` | `--max-num-seqs` | `128` |
+| `MAX_NUM_BATCHED_TOKENS` | `--max-num-batched-tokens` | `2048` |
+| `MAX_MODEL_LEN` | `--max-model-len`, omitted when blank | blank |
+| `DTYPE` | `--dtype` | `bfloat16` |
+| `KV_CACHE_DTYPE` | `--kv-cache-dtype` | `auto` |
+| `SEED` | `--seed` | `42` |
+| `TICK_SECONDS` | `--tick-seconds` | `1.0` |
+| `NUM_REQS` | `--num-reqs` | `0` |
+| `LOG_LEVEL` | `--log-level` | `INFO` |
+
+Note `TP=2` — the wrapper's default is not vLLM's `1`.
+
+### `bench/validate.sh`
+
+Positional, with three environment overrides:
+
+```bash
+./bench/validate.sh <bench_dir> <sim_csv> <sim_log> [prefix]
+```
+
+| Position / variable | Flag it sets | Default |
+| --- | --- | --- |
+| `$1` | `--bench-dir` | required |
+| `$2` | `--sim-csv` | required |
+| `$3` | `--sim-log` | required |
+| `$4` | `--prefix`, omitted when blank | blank |
+| `OUTPUT_SUBDIR` | `--output-subdir` | `validation` |
+| `TITLE` | `--title` | `vLLM vs LLMServingSim` |
+| `LOG_LEVEL` | `--log-level` | `INFO` |
+
+## Committed examples
+
+`bench/examples/` holds three end-to-end runs — a dense single-GPU
+baseline, a TP=2 dense run, and a DP+EP MoE run — each bundling the
+vLLM artifacts, the simulator output, and the resulting validation
+summary and plots. `bench/examples/run.sh` re-runs the simulator side
+and `bench/examples/validate.sh` re-runs the comparison. The headline
+numbers are on **[Validation](/docs/validation)**.
+
+## What's next
+
+- **[Validation](/docs/validation)**: what these runs actually measured.
+- **[For Contributors → Validating your changes](/docs/contributor/validating-changes)**:
+  the regression workflow that uses this harness.
+- **[Workloads → ShareGPT generators](/docs/workloads/sharegpt-generators)**:
+  producing a dataset for `--dataset`.

--- a/docs/docs/reference/cli-flags.md
+++ b/docs/docs/reference/cli-flags.md
@@ -9,6 +9,14 @@ Complete reference for every command-line flag accepted by
 `python -m serving`. For the conceptual side of each flag (what it
 *does* internally), see **[Simulator](/docs/simulator/architecture)**.
 
+:::tip 14 of these can be set per instance
+Flags marked **(per-instance)** below can also be written into an
+individual `instances[i]` object in the cluster config, which wins over
+the CLI value for that instance only. That is how one run serves
+heterogeneous instances. The other 15 flags are cluster-wide. See
+**[Cluster config → Runtime overrides](./cluster-config#runtime-overrides-optional)**.
+:::
+
 ## Cluster topology
 
 | Flag | Type | Default | Description |
@@ -24,13 +32,13 @@ matching runtime knobs per `instances[i]`; see
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--max-num-seqs` | int | `128` | Max sequences in a batch. `0` = unlimited |
-| `--max-num-batched-tokens` | int | `2048` | Max tokens per iteration across all requests (token budget) |
-| `--long-prefill-token-threshold` | int | `0` | Per-request token cap per step for chunked prefill. `0` = disabled |
-| `--enable-chunked-prefill` | bool | `True` | Split long prefill across iterations. Use `--no-enable-chunked-prefill` to disable |
-| `--npu-memory-utilization` | float | `0.9` | Fraction of NPU memory usable for weights plus KV cache. Corresponds to vLLM's `--gpu-memory-utilization`; KV capacity is `npu_mem.mem_size * this - model weight`. Override per instance with `npu_mem.mem_util` |
-| `--reserve-full-isl` / `--no-reserve-full-isl` | flag | on | Admit a request only if its whole sequence fits, not merely its first chunk. Mirrors vLLM's `scheduler_reserve_full_isl`; without it chunked prefill over-admits and thrashes the KV cache |
-| `--block-size` | int | `16` | KV cache block size in tokens |
+| `--max-num-seqs` **(per-instance)** | int | `128` | Max sequences in a batch. `0` = unlimited |
+| `--max-num-batched-tokens` **(per-instance)** | int | `2048` | Max tokens per iteration across all requests (token budget). Clamped to the model config's `max_position_embeddings`, so `0` ("unlimited") resolves to the context length, not infinity |
+| `--long-prefill-token-threshold` **(per-instance)** | int | `0` | Per-request token cap per step for chunked prefill. `0` = disabled |
+| `--enable-chunked-prefill` **(per-instance)** | bool | `True` | Split long prefill across iterations. Use `--no-enable-chunked-prefill` to disable |
+| `--npu-memory-utilization` **(per-instance,** as `npu_mem.mem_util`**)** | float | `0.9` | Fraction of NPU memory usable for weights plus KV cache. Corresponds to vLLM's `--gpu-memory-utilization`; KV capacity is `npu_mem.mem_size * this - model weight`. Override per instance with `npu_mem.mem_util` |
+| `--reserve-full-isl` / `--no-reserve-full-isl` **(per-instance)** | flag | on | Admit a request only if its whole sequence fits, not merely its first chunk. Mirrors vLLM's `scheduler_reserve_full_isl`; without it chunked prefill over-admits and thrashes the KV cache |
+| `--block-size` **(per-instance)** | int | `16` | KV cache block size in tokens |
 | `--skip-prefill` | flag | off | Skip prefill, run decode only |
 
 ## Routing
@@ -39,25 +47,25 @@ matching runtime knobs per `instances[i]`; see
 | --- | --- | --- | --- |
 | `--request-routing-policy` | `LOAD` / `RR` / `RAND` / `CUSTOM` | `LOAD` | Cross-instance request routing |
 | `--expert-routing-policy` | `BALANCED` / `RR` / `RAND` / `CUSTOM` | `BALANCED` | MoE expert token routing |
-| `--enable-block-copy` | bool | `True` | Replay one block's trace across layers (set False for per-layer EP variance) |
+| `--enable-block-copy` **(per-instance)** | bool | `True` | Replay one block's trace across layers (set False for per-layer EP variance) |
 
 ## Precision
 
 | Flag | Choices | Default | Description |
 | --- | --- | --- | --- |
-| `--dtype` | `float16` / `bfloat16` / `float32` / `fp8` / `int8` | model's `torch_dtype`, fallback `bfloat16` | Model weight dtype |
-| `--kv-cache-dtype` | `auto` / `fp8` | `auto` (inherits dtype) | KV cache dtype. `fp8` halves KV memory and selects a `*-kvfp8` profile variant |
+| `--dtype` **(per-instance)** | `float16` / `bfloat16` / `float32` / `fp8` / `int8` | model's `torch_dtype`, fallback `bfloat16` | Model weight dtype |
+| `--kv-cache-dtype` **(per-instance)** | `auto` / `fp8` | `auto` (inherits dtype) | KV cache dtype. `fp8` halves KV memory and selects a `*-kvfp8` profile variant |
 
 ## Prefix caching and offloading
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--enable-prefix-caching` | `True` | Prefix caching over a per-tier block pool with chained block hashes. Use `--no-enable-prefix-caching` to disable |
+| `--enable-prefix-caching` **(per-instance)** | `True` | Prefix caching over a per-tier block pool with chained block hashes. Use `--no-enable-prefix-caching` to disable |
 | `--enable-prefix-sharing` | off | Second-tier prefix pool shared across instances within a node |
 | `--prefix-storage` | `None` | Where the second-tier pool lives. `None` / `CPU` / `CXL` |
-| `--enable-local-offloading` | off | Weight offloading to NPU (counts weight reads in profiling) |
-| `--enable-attn-offloading` | off | Attention computation offloading to PIM |
-| `--enable-sub-batch-interleaving` | off | Overlap GPU compute with PIM attention. Requires `--enable-attn-offloading` |
+| `--enable-local-offloading` **(per-instance)** | off | Weight offloading to NPU (counts weight reads in profiling) |
+| `--enable-attn-offloading` **(per-instance)** | off | Attention computation offloading to PIM |
+| `--enable-sub-batch-interleaving` **(per-instance)** | off | Overlap GPU compute with PIM attention. Requires `--enable-attn-offloading` |
 
 ## Dataset and output
 
@@ -101,6 +109,7 @@ removed after a successful simulation by default.
 | PIM attention offload | `--enable-attn-offloading` (cluster config sets `pim_config`) |
 | FP8 KV cache | `--kv-cache-dtype fp8` |
 | ns3 backend | `--network-backend ns3` |
+| Heterogeneous instances in one run | (cluster config per-instance overrides; see the tip above) |
 
 For the full conceptual treatment of each feature, browse the
 **[Simulator](/docs/simulator/architecture)** section. For runnable

--- a/docs/docs/reference/cluster-config.md
+++ b/docs/docs/reference/cluster-config.md
@@ -58,7 +58,7 @@ bandwidth/latency per topology dimension.
 | `mem_size` | float | ✓ | Capacity per device in **GB** |
 | `mem_bw` | float | ✓ | Bandwidth per device in **GB/s** |
 | `mem_latency` | float | ✓ | Access latency in **ns** |
-| `num_devices` | int | ✓ | Number of CXL devices (`cxl:0` through `cxl:N-1`) |
+| `num_devices` | int | optional (default `1`) | Number of CXL devices (`cxl:0` through `cxl:N-1`) |
 
 When present, instances can reference `cxl:N` in their `placement`
 field.
@@ -122,6 +122,22 @@ schema. Top-level structure:
 | `nic.num_nics`, `nic.idle_power` | ✓ | NIC count and baseline |
 | `storage.num_devices`, `storage.idle_power` | ✓ | Storage devices |
 
+Three rules the table cannot show:
+
+- **Power modeling is all-or-nothing across the cluster.** If *any*
+  node omits `power`, `config_builder.py` disables power modeling for
+  **every** node, silently. There is no per-node opt-in.
+- **`npu` needs one entry per distinct `hardware` on that node.** The
+  key is the instance's `hardware` string, and every instance on the
+  node must find its own key. A heterogeneous node needs one block per
+  hardware label.
+- **`dram.dimm_size` and `dram.idle_power` become optional under
+  `--enable-attn-offloading`.** With PIM on, both are supplied by the
+  PIM config instead (`dimm_size` from the derived per-channel
+  capacity, `idle_power` from the INI's `idle_power`), and only
+  `dram.energy_per_bit` stays required. See
+  **[PIM config](./pim-config)**.
+
 ## Per-instance (`instances[i]`)
 
 ```json
@@ -172,9 +188,22 @@ schema. Top-level structure:
 
 ### Runtime overrides (optional)
 
-These fields override the matching `python -m serving` CLI flag for this
-instance only. Omitted fields keep the CLI value; for `dtype`, an omitted CLI
-value still falls back to the model config's `torch_dtype`.
+Exactly **14** of the `python -m serving` flags can be re-specified per
+instance, letting one cluster run heterogeneous instances — a prefill
+instance with a tight `max_num_seqs` next to a decode instance with a
+wide one, or two instances at different `mem_util`. Every one of them
+is resolved in `_build_instance_runtime_configs()` in
+`serving/__main__.py`.
+
+**Precedence** is one level deep, no merging:
+
+```
+instances[i].<field>   >   --<field> on the CLI   >   built-in default
+```
+
+The lookup is literally `instance.get("<field>", args.<field>)`, so a
+field present in the cluster config wins for that instance and every
+other instance keeps the CLI value.
 
 | Field | Type | CLI fallback | Description |
 | --- | --- | --- | --- |
@@ -186,12 +215,98 @@ value still falls back to the model config's `torch_dtype`.
 | `kv_cache_dtype` | string | `--kv-cache-dtype` | KV-cache dtype for memory accounting and profile variant selection |
 | `enable_chunked_prefill` | bool | `--enable-chunked-prefill` | Enable chunked prefill in this instance's scheduler |
 | `enable_prefix_caching` | bool | `--enable-prefix-caching` | Enable this instance's local prefix cache |
-| `npu_mem.mem_util` | float | `--npu-memory-utilization` | Fraction of `npu_mem.mem_size` usable for weights plus KV cache. KV capacity is `mem_size * mem_util - model weight`, divided into `--block-size` blocks |
+| `npu_mem.mem_util` | float | `--npu-memory-utilization` | Fraction of `npu_mem.mem_size` usable for weights plus KV cache. KV capacity is `mem_size * mem_util - model weight`, divided into `block_size` blocks |
 | `reserve_full_isl` | bool | `--reserve-full-isl` | Admit only if the request's whole sequence fits, not just its first chunk |
 | `enable_local_offloading` | bool | `--enable-local-offloading` | Emit graph conversion with local offloading for this instance |
 | `enable_attn_offloading` | bool | `--enable-attn-offloading` | Emit PIM attention offload for this instance |
 | `enable_sub_batch_interleaving` | bool | `--enable-sub-batch-interleaving` | Enable sub-batch interleaving for this instance |
 | `enable_block_copy` | bool | `--enable-block-copy` | Reuse one block trace across repeated transformer blocks |
+
+#### `npu_mem.mem_util` is the one nested override
+
+The other 13 are plain keys on the instance object. `mem_util` sits
+**inside** the `npu_mem` block, because its only job is to scale
+`mem_size` and it follows that block's `mem_*` naming:
+
+```json
+{
+  "model_name": "meta-llama/Llama-3.1-8B",
+  "hardware": "RTXPRO6000",
+  "npu_mem": {"mem_size": 96, "mem_bw": 1597, "mem_latency": 0, "mem_util": 0.8},
+  "tp_size": 1,
+  "pd_type": null,
+  "max_num_seqs": 64
+}
+```
+
+It must be a number in `(0, 1]` — it is a *fraction*, so `0.9`, never
+`90`. Anything else raises at startup rather than being clamped.
+
+#### `0` means unlimited, with one caveat
+
+`max_num_seqs` and `max_num_batched_tokens` route through a
+`_runtime_limit()` helper that maps `0` to infinity:
+
+- `max_num_seqs: 0` — genuinely unbounded concurrency.
+- `max_num_batched_tokens: 0` — **not** unbounded in practice. The
+  scheduler then computes
+  `min(max_num_batched_tokens, max_position_embeddings)`, so the
+  effective budget becomes the model's context length from
+  **[Model config](./model-config)**. On
+  `microsoft/Phi-mini-MoE-instruct` that is 4096, not infinity.
+
+No other numeric override treats `0` specially:
+`long_prefill_token_threshold: 0` means *disabled* (no per-request
+cap), matching the CLI flag, and `block_size: 0` is simply invalid.
+
+#### `dtype` resolution is three levels, not two
+
+`dtype` is the one override with a fallback below the CLI:
+
+```
+instances[i].dtype   >   --dtype   >   model config torch_dtype   >   bfloat16
+```
+
+The resolved value must be one of `float16` / `bfloat16` / `float32` /
+`fp8` / `int8`, and it selects the profile **variant folder**, so the
+matching `profiler/perf/<hardware>/<model>/<variant>/tp<N>/` bundle has
+to exist. `kv_cache_dtype` is validated per instance too — only `auto`
+or `fp8`.
+
+#### Validation gates
+
+Two combinations are rejected at config-load time, per instance:
+
+| Rejected | Error | Why |
+| --- | --- | --- |
+| `enable_sub_batch_interleaving: true` without `enable_attn_offloading: true` | `RuntimeError` | There is nothing to overlap the NPU sub-batch against |
+| `enable_sub_batch_interleaving: true` with `pp_size > 1` | `RuntimeError` | An interleaved trace leaves both sub-batches mid-block at every stage edge, so a pipeline stage has no single hidden state to pass on |
+
+Both gates read the *effective* values, so inheriting
+`--enable-sub-batch-interleaving` from the CLI onto an instance that
+locally disables `enable_attn_offloading` fails just the same.
+
+#### Flags that are **not** per-instance
+
+The remaining 15 CLI flags are cluster-wide. Setting them inside an
+instance object is silently ignored — nothing reads the key:
+
+| Scope | Flags |
+| --- | --- |
+| Cluster / backend | `--cluster-config`, `--network-backend` |
+| Router (cross-instance by definition) | `--request-routing-policy`, `--expert-routing-policy` |
+| Shared lower KV tier | `--enable-prefix-sharing`, `--prefix-storage` |
+| Workload (one per run) | `--dataset`, `--num-reqs`, `--skip-prefill` |
+| Run plumbing | `--output`, `--run-id`, `--inputs-root`, `--cleanup-inputs`, `--log-interval`, `--log-level` |
+
+#### Worked example
+
+`configs/cluster/single_node_pd_per_instance_config.json` splits
+prefill and decode with different scheduler limits, and
+`configs/cluster/single_node_heterogeneous.json` pairs them with
+different chunked-prefill settings. See
+**[Examples → Cluster config explained](/docs/examples/cluster-config-explained#per-instance-runtime-overrides)**
+for the annotated walkthrough.
 
 ### `placement` (optional)
 
@@ -231,13 +346,36 @@ canonical layer names from the architecture YAML.
 
 ## Validation rules
 
+Structural, in `config_builder.py`:
+
 - `num_nodes == len(nodes)` and per-node `num_instances == len(instances)`.
-- Per-instance `weight_per_gpu * num_npus <= npu_mem.mem_size *
-  num_npus` (otherwise startup OOM).
-- Hardware folder must exist at `profiler/perf/<hardware>/<model_name>/<variant>/tp<tp_size>/`.
-- `dp_group` must be a valid string or `null`.
-- All instances within the same `dp_group` must share the same
-  `ep_size` and `tp_size`.
+- `link_bw` and `link_latency` must both be present at top level.
+- Every instance needs `model_name`, `hardware`, `npu_mem`, and
+  `pd_type`; `npu_mem` needs `mem_size`, `mem_bw`, `mem_latency`. Same
+  three keys are required in `cpu_mem` and, if present, `cxl_mem`.
+- `num_npus == tp_size * pp_size`, and `pp_size <= num_hidden_layers`.
+- `dp_group` must be a string or `null`, and all instances sharing one
+  `dp_group` must agree on `tp_size` **and** `ep_size`.
+- Hardware folder must exist at
+  `profiler/perf/<hardware>/<model_name>/<variant>/tp<tp_size>/`.
+
+Memory, in `memory_model.py`, evaluated **per GPU** (weights are
+already sharded by `tp_size` / `ep_size`):
+
+- `weight_per_gpu <= npu_mem.mem_size`, ignoring `mem_util`. Failing
+  this raises `Model size ...GB exceeds total NPU memory ...GB`.
+- `npu_mem.mem_size * mem_util - weight_per_gpu` must leave room for at
+  least **one** KV block of `block_size` tokens. This is the tighter of
+  the two and the one `mem_util` actually gates: dropping `mem_util`
+  far enough fails here, with a message naming the requested bytes,
+  the weight bytes, and the shortfall.
+
+Runtime, per instance, in `serving/__main__.py`:
+
+- `dtype` must be one of the five supported values and
+  `kv_cache_dtype` one of `auto` / `fp8`.
+- `npu_mem.mem_util` must be a number in `(0, 1]`.
+- The two sub-batch-interleaving gates above.
 
 ## What's next
 

--- a/docs/docs/reference/model-config.md
+++ b/docs/docs/reference/model-config.md
@@ -46,6 +46,7 @@ profiler downloads and caches it on first run. The simulator
 | `intermediate_size` | int | both | MLP intermediate dim |
 | `vocab_size` | int | both | Embedding / `lm_head` output dim |
 | `head_dim` | int | both | **Important if not `hidden_size / num_attention_heads`** (Qwen3 has explicit `head_dim`) |
+| `max_position_embeddings` | int | simulator | **Required.** The model's context limit. The simulator clamps its per-step token budget to it: `max_num_batched_tokens = min(max_num_batched_tokens, max_position_embeddings)` |
 
 When `head_dim` is absent from the config, the simulator falls back
 to `hidden_size // num_attention_heads`. This is wrong for Qwen3
@@ -71,15 +72,27 @@ or `num_experts` and treats them equivalently.
 | --- | --- | --- |
 | `torch_dtype` | string | Default weight dtype. Used when `--dtype` isn't passed. e.g. `bfloat16`, `float16`, `float32` |
 | `architectures` | array | First entry's class name is informational; the simulator dispatches via `model_type` |
-| `mlp_only_layers` | array | Indices of layers using dense MLP (vs MoE). Hybrid MoE/dense models like Qwen3-MoE-Instruct use this |
 
 ## Fields the simulator ignores
 
 The HF config has many more fields the simulator doesn't use -
 things like `bos_token_id`, `eos_token_id`, `attention_dropout`,
-`max_position_embeddings`, `rope_*`, `rms_norm_eps`,
-`initializer_range`, `tie_word_embeddings`. Leave them as the HF
-config has them; ignored fields don't affect simulation.
+`rope_*`, `rms_norm_eps`, `initializer_range`,
+`tie_word_embeddings`. Leave them as the HF config has them; ignored
+fields don't affect simulation.
+
+`max_position_embeddings` is **not** in that group, despite looking
+like a pure-HF field: see the required table above.
+
+`mlp_only_layers` **is** ignored, and that one has a consequence worth
+knowing. Qwen3-MoE ships it to mark which decoder layers use a dense
+MLP instead of the MoE block, and
+`configs/model/Qwen/Qwen3-30B-A3B-Instruct-2507.json` carries it. The
+simulator decides MoE-ness once per *model* (`is_moe` is true when the
+config has `num_local_experts` or `num_experts`) and applies the MoE
+path to every layer, so a hybrid model's dense layers are modelled as
+MoE layers. On Qwen3-30B-A3B that list is empty, so nothing is lost
+today — but a genuinely hybrid config would be mis-modelled silently.
 
 ## Examples
 
@@ -95,6 +108,7 @@ config has them; ignored fields don't affect simulation.
   "num_hidden_layers": 32,
   "num_key_value_heads": 8,
   "vocab_size": 128256,
+  "max_position_embeddings": 131072,
   "torch_dtype": "bfloat16"
 }
 ```
@@ -115,6 +129,7 @@ Llama 3.1.)
   "num_key_value_heads": 8,
   "head_dim": 128,
   "vocab_size": 151936,
+  "max_position_embeddings": 40960,
   "torch_dtype": "bfloat16"
 }
 ```
@@ -138,6 +153,7 @@ Llama 3.1.)
   "num_experts_per_tok": 8,
   "moe_intermediate_size": 768,
   "vocab_size": 151936,
+  "max_position_embeddings": 262144,
   "torch_dtype": "bfloat16"
 }
 ```
@@ -164,6 +180,19 @@ Llama 3.1.)
    the model's HF config uses; the simulator handles both.
 3. **`model_type` is case-sensitive** and must match a YAML at
    `profiler/models/<model_type>.yaml` exactly.
+4. **`max_position_embeddings` silently caps the token budget.** The
+   scheduler and trace generator both read it as
+   `min(max_num_batched_tokens, max_position_embeddings)`. On a
+   short-context model this bites without warning: bundled
+   `microsoft/Phi-mini-MoE-instruct` has
+   `max_position_embeddings: 4096`, so
+   `--max-num-batched-tokens 8192` actually runs at 4096. It also
+   sets the ceiling for `max_num_batched_tokens: 0`
+   ("unlimited"), which resolves to `max_position_embeddings`
+   rather than to infinity.
+5. **It is read with a direct index, not a `.get()`.** A config
+   without `max_position_embeddings` raises `KeyError` at scheduler
+   construction rather than falling back to a default.
 
 ## What's next
 

--- a/docs/docs/reference/pim-config.md
+++ b/docs/docs/reference/pim-config.md
@@ -33,18 +33,73 @@ The cluster config references one of these via the node's
 }
 ```
 
-## Bundled configs
+## Bundled configs and their derived values
 
-| File | Protocol | Capacity | Speed | Notes |
-| --- | --- | --- | --- | --- |
-| `DDR4_8GB_3200_pim.ini` | DDR4 | 8 GB | 3200 MT/s | Standard DDR4 PIM module |
-| `HBM2_1GB_2000_pim.ini` | HBM2 | 1 GB | 2000 MT/s | HBM2 PIM (high-bandwidth) |
-| `LPDDR4X_2GB_4266_pim.ini` | LPDDR4X | 2 GB | 4266 MT/s | Mobile-class PIM |
-| `LPDDR5_2GB_6400_pim.ini` | LPDDR5 | 2 GB | 6400 MT/s | Mobile-class PIM, faster |
+The four bundled files, with the quantities `pim_model.py` derives
+from them (see [How the numbers are derived](#how-the-numbers-are-derived)):
+
+| File | Protocol | `data_rate` | Per-channel capacity | Per-channel BW | Read latency |
+| --- | --- | --- | --- | --- | --- |
+| `DDR4_8GB_3200_pim.ini` | DDR4 | 3200 MT/s | 8 GB | 25.6 GB/s | 13.86 ns |
+| `HBM2_1GB_2000_pim.ini` | HBM | 2000 MT/s | 1 GB | 32.0 GB/s | 14.00 ns |
+| `LPDDR4X_2GB_4266_pim.ini` | LPDDR4X | 4266 MT/s | 2 GB | 8.53 GB/s | 16.85 ns |
+| `LPDDR5_2GB_6400_pim.ini` | LPDDR5 | 6400 MT/s | 2 GB | 12.80 GB/s | 10.62 ns |
+
+The capacity in each filename is the **per-channel** capacity, not the
+device total. How many channels a node has is derived from
+`cpu_mem.mem_size`, not declared in the INI: a 512 GB node with
+`DDR4_8GB_3200_pim` gets `512 / 8 = 64` channels and an aggregate
+`64 x 25.6 = 1638 GB/s`.
+
+:::warning Adding a fifth config takes a code change
+`pim_model.py` matches the INI's **filename stem** against a
+hard-coded table of calibrated latency coefficients. A new `.ini`
+alone raises `ValueError: Unknown PIM spec: <stem>`. See
+**[Adding a new PIM config](#adding-a-new-pim-config)**.
+:::
 
 ## INI structure
 
-Each PIM config has three sections.
+The bundled files carry **five** sections, in DRAMSim3 order:
+`[dram_structure]`, `[timing]`, `[power]`, `[system]`, `[other]`.
+
+**The loader ignores section headers.** `pim_model.py`'s
+`load_flat_config()` reads the file line by line, skips anything
+starting with `[` or `;`, strips `#` comments, and flattens every
+`key = value` pair into one dict. Consequences:
+
+- Key names must be **unique across the whole file**, not just within
+  a section. Sections are organization for human readers and for
+  DRAMSim3 itself, nothing more.
+- Values are coerced by shape: a token containing `.` becomes a
+  float, an all-digit token becomes an int, anything else stays a
+  string.
+- Trailing `# comments` are safe on any line, including section
+  headers.
+
+Of the ~50 keys in a bundled file, the simulator reads **eleven**.
+The rest are carried for DRAMSim3 fidelity and are inert here.
+
+### Keys the simulator actually reads
+
+| Key | Section | Used for |
+| --- | --- | --- |
+| `bankgroups` | `[dram_structure]` | `banks = bankgroups * banks_per_group` |
+| `banks_per_group` | `[dram_structure]` | same |
+| `rows` | `[dram_structure]` | per-bank capacity |
+| `columns` | `[dram_structure]` | page size |
+| `device_width` | `[dram_structure]` | page size, devices per rank |
+| `CL` | `[timing]` | read latency |
+| `tCK` | `[timing]` | read latency |
+| `bus_width` | `[system]` | channel bandwidth, devices per rank |
+| `channel_size` | `[system]` | per-channel capacity target, in MB |
+| `data_rate` | `[other]` | channel bandwidth |
+| `idle_power` | `[other]` | power model, in mW |
+| `peak_power` | `[other]` | power model, in mW |
+
+`data_rate`, `idle_power`, and `peak_power` are **not** DRAMSim3
+fields. They are LLMServingSim additions parked in `[other]`, and
+they are required: a config without them raises `KeyError`.
 
 ### `[dram_structure]`
 
@@ -60,51 +115,61 @@ BL = 8
 pim_type = SINGLE
 ```
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `protocol` | string | DRAM standard. `DDR4`, `DDR5`, `HBM2`, `HBM3`, `LPDDR4`, `LPDDR4X`, `LPDDR5` |
-| `bankgroups` | int | Bank groups per device |
-| `banks_per_group` | int | Banks per bank group |
-| `rows` | int | Rows per bank |
-| `columns` | int | Columns per row |
-| `device_width` | int | Device data width in bits (typically 4 / 8 / 16) |
-| `BL` | int | Burst length |
-| `pim_type` | enum | `SINGLE` (one PIM unit per channel) or `DUAL` (two units per channel) |
-
-The simulator computes:
-
-- **Bandwidth** from `device_width × BL × tCK × channel_count`.
-- **Capacity** from `rows × columns × device_width × banks × bankgroups`.
+| Field | Type | Read? | Description |
+| --- | --- | --- | --- |
+| `protocol` | string | no | DRAM standard. `DDR4`, `DDR5`, `HBM`, `LPDDR4X`, `LPDDR5` |
+| `bankgroups` | int | **yes** | Bank groups per device |
+| `banks_per_group` | int | **yes** | Banks per bank group |
+| `rows` | int | **yes** | Rows per bank |
+| `columns` | int | **yes** | Columns per row |
+| `device_width` | int | **yes** | Device data width in bits (4 / 8 / 16 / 128) |
+| `BL` | int | no | Burst length. Carried for DRAMSim3; the bandwidth model uses `data_rate` instead |
+| `pim_type` | enum | no | `SINGLE` / `DUAL`. Not read by `pim_model.py` |
 
 ### `[timing]`
 
 ```ini
 [timing]
 tCK = 0.63          # clock period in ns
-CL = 22             # CAS latency
-CWL = 16            # CAS write latency
-tRCD = 22           # RAS-to-CAS delay
-tRP = 22            # row precharge time
-tRAS = 52           # row active time
-tRFC = 560          # refresh cycle
-tREFI = 12480       # refresh interval
-tRRD_S = 9          # row-to-row delay (different bank groups)
-tRRD_L = 11         # row-to-row delay (same bank group)
-tWTR_S = 4          # write-to-read delay (different bank groups)
-tWTR_L = 12         # write-to-read delay (same bank group)
-tFAW = 48           # four-activate window
-tWR = 24            # write recovery
-tRTP = 12           # read-to-precharge delay
-tCCD_S = 4          # CAS-to-CAS (different bank groups)
-tCCD_L = 8          # CAS-to-CAS (same bank group)
+CL = 22             # CAS latency, in cycles
+CWL = 16
+tRCD = 22
+tRP = 22
+tRAS = 52
+# ... the full DRAMSim3 timing set follows
 ```
 
-All timing parameters are in **clock cycles** unless explicitly named
-otherwise (`tCK` is in ns). The full list mirrors DRAMSim3's spec.
-The simulator extracts the latency-relevant subset for PIM access
-modeling.
+Only `tCK` and `CL` are read. Everything else in this section is
+carried for DRAMSim3 fidelity and does not affect simulation.
 
-For full DRAMSim3 timing semantics, see the [DRAMSim3 docs](https://github.com/umd-memsys/DRAMsim3).
+| Field | Unit | Read? | Description |
+| --- | --- | --- | --- |
+| `tCK` | ns | **yes** | Clock period |
+| `CL` | cycles | **yes** | CAS latency |
+| everything else | cycles | no | `CWL`, `tRCD`, `tRP`, `tRAS`, `tRFC`, `tREFI`, `tRRD_*`, `tWTR_*`, `tFAW`, `tWR`, `tRTP`, `tCCD_*`, `tCKE`, `tXS`, `tXP`, `tRTRS`, ... |
+
+For full DRAMSim3 timing semantics, see the
+[DRAMSim3 docs](https://github.com/umd-memsys/DRAMsim3).
+
+### `[power]`
+
+Standard DRAMSim3 current/voltage rails. **None of these are read**:
+PIM power comes from `idle_power` / `peak_power` in `[other]`.
+
+```ini
+[power]
+VDD = 1.2
+IDD0 = 95
+IPP0 = 4.0
+IDD2P = 25
+IDD2N = 37
+IDD3P = 47
+IDD3N = 56
+IDD4W = 278
+IDD4R = 302
+IDD5AB = 280
+IDD6x = 30
+```
 
 ### `[system]`
 
@@ -118,41 +183,178 @@ queue_structure = PER_BANK
 row_buf_policy = OPEN_PAGE
 ```
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `channel_size` | int | Per-channel capacity in MB |
-| `channels` | int | Number of memory channels (PIM compute happens per-channel) |
-| `bus_width` | int | Memory bus width in bits |
-| `address_mapping` | string | DRAMSim3 address-mapping scheme |
-| `queue_structure` | enum | Queueing policy (`PER_BANK`, `PER_CHANNEL`, etc.) |
-| `row_buf_policy` | enum | Row buffer policy (`OPEN_PAGE`, `CLOSE_PAGE`) |
+| Field | Type | Read? | Description |
+| --- | --- | --- | --- |
+| `channel_size` | int | **yes** | Target per-channel capacity in **MB**. Rounded to a whole number of ranks (see below) |
+| `channels` | int | no | **Ignored.** Channel count is derived from the node's `cpu_mem.mem_size`, not from this field |
+| `bus_width` | int | **yes** | Memory bus width in bits |
+| `address_mapping` | string | no | DRAMSim3 address-mapping scheme |
+| `queue_structure` | enum | no | DRAMSim3 queueing policy |
+| `row_buf_policy` | enum | no | DRAMSim3 row buffer policy |
 
-`channels` is the most simulator-relevant field: more channels =
-more parallel PIM compute per attention step. The trace generator
-distributes attention heads across channels for parallel execution.
+### `[other]`
+
+```ini
+[other]
+epoch_period = 1587301
+output_level = 1
+data_rate = 3200 # MT/s
+idle_power = 623 # mW
+peak_power = 3803 # mW
+```
+
+| Field | Unit | Read? | Description |
+| --- | --- | --- | --- |
+| `data_rate` | MT/s | **yes** | Transfers per second. Drives per-channel bandwidth |
+| `idle_power` | mW | **yes** | Per-DIMM idle power. Becomes `power.dram.idle_power` in W |
+| `peak_power` | mW | **yes** | Per-DIMM active power. Becomes `power.dram.pim_active_power` in W |
+| `epoch_period` | cycles | no | DRAMSim3 stat-dump interval |
+| `output_level` | int | no | DRAMSim3 verbosity |
+
+## How the numbers are derived
+
+`PIMModel.init_dram_params()` turns the INI plus the node's
+`cpu_mem.mem_size` into four values. All of it is closed-form, no
+DRAMSim3 process is spawned.
+
+**Per-channel capacity** (`dimm_size`, in GB):
+
+```
+banks            = bankgroups * banks_per_group
+devices_per_rank = bus_width / device_width
+page_size        = columns * device_width / 8          # bytes
+megs_per_bank    = page_size * (rows / 1024) / 1024    # MB
+megs_per_rank    = megs_per_bank * banks * devices_per_rank
+
+# channel_size from the INI is a target, snapped to whole ranks
+if megs_per_rank > channel_size:
+    channel_size = megs_per_rank                       # one rank, minimum
+else:
+    channel_size = (channel_size / megs_per_rank) * megs_per_rank
+
+ch_capacity = channel_size / 1024                      # GB
+```
+
+**Per-channel bandwidth** (GB/s) — note that `BL` and `tCK` do *not*
+appear here:
+
+```
+ch_bw = bus_width / 8 * data_rate / 1000
+```
+
+**Channel count and aggregate bandwidth**, from the node's host memory
+size:
+
+```
+num_ch  = cpu_mem.mem_size / ch_capacity
+mem_bw  = num_ch * ch_bw
+```
+
+**Read latency** (ns):
+
+```
+mem_latency = CL * tCK
+```
+
+Worked example, `DDR4_8GB_3200_pim` on a 512 GB node:
+
+```
+banks            = 2 * 4 = 8
+devices_per_rank = 64 / 16 = 4
+page_size        = 1024 * 16 / 8 = 2048 B
+megs_per_bank    = 2048 * 64 / 1024 = 128 MB
+megs_per_rank    = 128 * 8 * 4 = 4096 MB
+channel_size     = (8192 / 4096) * 4096 = 8192 MB -> ch_capacity = 8 GB
+ch_bw            = 64 / 8 * 3200 / 1000 = 25.6 GB/s
+num_ch           = 512 / 8 = 64
+mem_bw           = 64 * 25.6 = 1638.4 GB/s
+mem_latency      = 22 * 0.63 = 13.86 ns
+```
+
+### These values overwrite the node's `cpu_mem`
+
+When a node sets `cpu_mem.pim_config`, `config_builder.py` replaces
+that node's `cpu_mem.mem_bw` and `cpu_mem.mem_latency` with the
+derived values above, and logs a warning for each one it overwrites.
+`cpu_mem.mem_size` is **not** overwritten: it is the input that
+decides the channel count. So with a PIM config, `mem_bw` and
+`mem_latency` in your cluster config are dead fields.
+
+`remote_mem` in the generated `memory_expansion.json` also picks up
+`pim-channels = cpu_mem.mem_size // ch_capacity` (integer division).
+
+## PIM attention latency model
+
+`get_pim_latency()` does not simulate DRAM. It evaluates a linear fit
+calibrated per spec against the Llama-3.1-8B shape
+(`n_head=32`, `kv_head=8`, `head_dim=128`), rescaled for the model
+actually being run:
+
+```
+gqa_ratio = (n_head / kv_head) / (32 / 8)
+kv_scale  = (n_head * head_dim) / (32 * 128)
+
+latency_ns = (slope * gqa_ratio * L + intercept * kv_scale) / channel_split
+```
+
+`L` is the sequence length and `channel_split` is the channel
+parallelism the trace generator hands in. The calibrated coefficients
+live in `pim_model.py::estimate_with_linear`:
+
+| Spec | `slope` | `intercept` |
+| --- | --- | --- |
+| `LPDDR4X_2GB_4266_pim` | 432.4458 | 33918.1734 |
+| `DDR4_8GB_3200_pim` | 333.2538 | 30675.2739 |
+| `LPDDR5_2GB_6400_pim` | 282.4338 | 15996.7018 |
+| `HBM2_1GB_2000_pim` | 242.0548 | 14513.5015 |
+
+The INI's structural fields feed *capacity, bandwidth, and read
+latency*. They do **not** feed the attention latency, which comes
+entirely from this table.
 
 ## Adding a new PIM config
 
-1. Drop a new `.ini` file at `configs/pim/<name>.ini`.
-2. Fill the three sections above. Reference the bundled configs for
-   the right shape.
+A new `.ini` is necessary but not sufficient. The spec name is
+whitelisted in code, so this takes two steps:
+
+1. Drop the file at `configs/pim/<name>.ini`. Populate at minimum the
+   eleven keys the simulator reads: `bankgroups`, `banks_per_group`,
+   `rows`, `columns`, `device_width`, `CL`, `tCK`, `bus_width`,
+   `channel_size`, `data_rate`, `idle_power`, `peak_power`. Copy a
+   bundled file and edit it rather than starting from scratch, so the
+   inert DRAMSim3 fields stay well-formed.
+2. **Add a `"<name>": {"slope": ..., "intercept": ...}` entry to the
+   `attn_model` dict in `serving/core/pim_model.py`.** The key is the
+   filename stem. Without it, `estimate_with_linear` raises
+   `ValueError: Unknown PIM spec: <name>` the first time an
+   offloaded attention layer is emitted.
 3. Reference it from your cluster config:
-   `"cpu_mem": {"pim_config": "<name>"}`.
+   `"cpu_mem": {"pim_config": "<name>"}` (no `.ini` extension).
 4. Run with `--enable-attn-offloading`.
 
-The DRAMSim3 timing parameters can be sourced from a JEDEC datasheet
-or vendor spec for the specific DRAM part you're modeling.
+Obtaining the coefficients means measuring or simulating PIM
+attention latency against sequence length on the target device and
+fitting a line, at the Llama-3.1-8B head shape the rescaling assumes.
+The structural DRAMSim3 timings can come from a JEDEC datasheet, but
+`slope` / `intercept` cannot be read off a spec sheet.
 
 ## Where this is used
 
-- **`serving/core/pim_model.py`**: loads the INI and exposes timing
-  parameters to the trace generator.
-- **`serving/core/trace_generator.py`**: when
-  `--enable-attn-offloading` is on, swaps NPU attention for
-  PIM attention computed using the loaded model.
-- **Power model**: if the cluster config has a `power:` block, PIM
-  energy is accounted for via the channel count (one PIM unit per
-  channel × per-channel power).
+- **`serving/core/pim_model.py`**: parses the INI flat, derives
+  capacity / bandwidth / read latency, and evaluates the linear
+  attention latency model.
+- **`serving/core/config_builder.py`**: instantiates one `PIMModel`
+  per node that sets `cpu_mem.pim_config`, and overwrites that node's
+  `cpu_mem.mem_bw` / `mem_latency` from it.
+- **`serving/core/trace_generator.py`**: with
+  `--enable-attn-offloading`, wraps PIM attention in
+  `PIM <channel>` / `PIM END` markers ahead of the NPU attention
+  kernel.
+- **Power model**: `idle_power` / `peak_power` become
+  `power.dram.idle_power` and `power.dram.pim_active_power` (mW to W),
+  and the derived per-channel capacity becomes `power.dram.dimm_size`.
+  Both override whatever the cluster config's `power.dram` block
+  declared.
 
 For the full PIM offload mechanics, see
 **[Simulator → PIM offload](/docs/simulator/specialized/pim-offload)**.
@@ -161,17 +363,23 @@ For a worked example, see
 
 ## Gotchas
 
-1. **All four bundled INI files use `pim_type = SINGLE`.** Switching
-   to `DUAL` doubles the per-channel PIM compute capacity but also
-   needs `pim_type = DUAL` to be supported by the cluster config's
-   power model entry.
-2. **`channels = N` doesn't mean N independent PIM devices.** The
-   simulator models per-channel parallelism within one PIM device.
-   For multiple PIM devices, you'd configure multiple nodes, but
-   that's a different topology.
-3. **The INI is parsed as DRAMSim3 standard.** Don't add custom
-   fields the simulator's loader doesn't know about; they'll be
-   ignored.
+1. **A new INI without a code change crashes.** The `attn_model`
+   whitelist in `pim_model.py` is keyed by filename stem. This is the
+   single most common surprise on this page.
+2. **`channels` in `[system]` is not read.** Channel count is
+   `cpu_mem.mem_size / per-channel capacity`. To model more parallel
+   PIM channels, raise the node's `cpu_mem.mem_size` or pick a config
+   with a smaller per-channel capacity, not `channels`.
+3. **`cpu_mem.mem_bw` and `cpu_mem.mem_latency` are ignored** on a
+   node with `pim_config`. They get overwritten from the INI, with a
+   warning. Only `mem_size` still matters.
+4. **Sections are cosmetic.** The loader flattens the file, so a key
+   repeated in two sections silently keeps the last occurrence.
+5. **`BL` and `pim_type` are inert.** Every bundled file says
+   `pim_type = SINGLE`; switching to `DUAL` changes nothing, because
+   `pim_model.py` never reads it.
+6. **Powers are milliwatts.** `idle_power = 623` means 0.623 W per
+   DIMM. Mixing in a watt-valued number inflates node power by 1000x.
 
 ## What's next
 

--- a/docs/docs/reference/trace-format.md
+++ b/docs/docs/reference/trace-format.md
@@ -40,13 +40,31 @@ sampler_291    25933    LOCAL    2565120    LOCAL    0    REMOTE:0    40    NONE
 
 | Line | Content | Meaning |
 | --- | --- | --- |
-| 1 | `COLOCATED\tmodel_parallel_NPU_group: {pp_size}` + optional `\tpp_stage_boundaries: {i1},{i2},…` | Trace mode marker followed by `key: value` pairs. `model_parallel_NPU_group` is the pipeline-parallel degree. `pp_stage_boundaries` is written only when `pp_size > 1`: the `pp_size - 1` layer-row indices at which each stage after the first begins, counted after any leading `kv_load`/`kv_evict` rows |
-| 2 | `{num_layers}` | Number of layer rows that follow |
-| 3 | column header (tab-separated) | Field names |
+| 1 | `{mode}\t\tmodel_parallel_NPU_group: {pp_size}` + optional `\t\tpp_stage_boundaries: {i1},{i2},…` | Mode marker followed by `key: value` pairs, separated by double tabs. `model_parallel_NPU_group` is the pipeline-parallel degree. `pp_stage_boundaries` is written only when `pp_size > 1`: the `pp_size - 1` layer-row indices at which each stage after the first begins, counted after any leading `kv_load`/`kv_evict` rows |
+| 2 | `{num_layers}` | Number of rows that follow, **including** any `kv_load` / `kv_evict` rows |
+| 3 | column header | Field names |
+
+The mode marker comes from the instance's `pd_type`:
+
+| Marker | `pd_type` | Converter path |
+| --- | --- | --- |
+| `COLOCATED` | `null` | combined prefill + decode |
+| `PREFILL` | `"prefill"` | adds the per-layer KV SEND to the paired decode NPU |
+| `DECODE` | `"decode"` | adds the matching RECV |
+
+Any other `pd_type` raises `ValueError: Unknown instance type` at
+trace-generation time.
 
 ### Layer rows
 
-Each row has 11 tab-separated fields:
+Each row has 11 fields, written as **fixed-width left-aligned
+columns** by `serving/core/utils.py::_FMT` — 30 characters for
+`Layername`, 15 for each of the rest, padded with spaces. Nothing is
+tab-separated. Both readers (`trace_generator`'s own re-read and the
+Chakra converter) split on runs of arbitrary whitespace
+(`re.findall(r'\S+', line)` and `line.strip().split()` respectively),
+so the column widths are for human legibility only and no field may
+contain a space.
 
 | Field | Type | Meaning |
 | --- | --- | --- |
@@ -59,7 +77,7 @@ Each row has 11 tab-separated fields:
 | `output_loc` | enum | Where the output tensor will be written |
 | `output_size` | int | Output tensor size in bytes |
 | `comm_type` | enum | Collective type after this layer (see [communication](#communication-types)) |
-| `comm_size` | int | Collective message size in bytes (`0` if `comm_type` is `NONE`) |
+| `comm_size` | int | Collective message size in bytes. Usually `0` when `comm_type` is `NONE`, but **not always**: on a `PREFILL` trace, `qkv_proj` carries the per-layer P/D KV transfer here while keeping `comm_type` at `NONE` (see [below](#comm_size-without-a-collective)) |
 | `misc` | string | Misc tag (sub-batch interleaving, etc.; usually `NONE`) |
 
 ## Memory locations
@@ -127,9 +145,65 @@ the `involved_dim` BoolList into the `.et` file. ASTRA-Sim's
 `Workload::issue_comm()` reads the BoolList and routes the collective
 on the named dimensions.
 
+## `comm_size` without a collective
+
+On a `PREFILL` trace, every `qkv_proj` row carries a non-zero
+`comm_size` while its `comm_type` stays `NONE`. This is not an
+inconsistency: the converter's prefill path emits a point-to-point
+SEND after each layer's KV projection rather than a collective, and a
+SEND needs only a size, a source, a destination, and a tag — there is
+no collective type to name.
+
+The value is the **per-layer, per-rank K+V** byte count, honouring
+`kv_cache_dtype`. It is deliberately *not* the layer's `output_size`,
+which is the whole QKV activation: reading that shipped Q as well and
+overstated the transfer by `(q_dim + 2 * kv_dim) / (2 * kv_dim)` — 3x
+on Llama-3.1-8B.
+
+Everywhere else, `comm_size` is `0` when `comm_type` is `NONE`.
+
 ## Special markers
 
 Some layers are wrapped by markers:
+
+### `kv_load` / `kv_evict` (tiered KV recall)
+
+When a lower KV tier is configured (`--prefix-storage CPU` or `CXL`), a
+step that recalls blocks from it prepends up to two rows **before** the
+first real layer:
+
+```
+kv_load    0    LOCAL    0    REMOTE:0    8388608    LOCAL    0    NONE    0    NONE
+kv_evict   0    LOCAL    0    REMOTE:0    2097152    LOCAL    0    NONE    0    NONE
+```
+
+They are not compute: `comp_time` is `0` and the byte count sits in
+`weight_size`, so the converter charges them as a memory transfer
+against the tier named in `weight_loc` — which is the instance's
+`placement` `kv_evict_loc`, not `kv_loc`.
+
+Each row is emitted only when its byte count is non-zero, so a step can
+have both, one, or neither. Without `--prefix-storage` there is no
+lower tier to recall from and both counts are always `0`, so neither
+row ever appears. `batch.evict` is `0` in every mode: eviction off the
+NPU costs nothing, because the data is either a finished request's
+cache or was already written down off the critical path.
+
+Two consequences worth knowing:
+
+- The `{num_layers}` count on header line 2 includes these rows.
+- `pp_stage_boundaries` indices are counted **after** they are
+  stripped, so they stay stable whether or not a step recalled
+  anything.
+
+### Layer-name suffixes
+
+Each row's `Layername` gets `_{i}` appended, where `i` is the row's
+index in the whole file — *including* any `kv_load` / `kv_evict` rows.
+So the same layer of the same model can carry different suffixes on
+different iterations, and the suffix is an identifier, not a layer
+number. `EXPERT` and `PIM` marker rows are the exception: they are
+written verbatim with no suffix.
 
 ### `EXPERT {i}` / `EXPERT END` (MoE)
 
@@ -176,24 +250,23 @@ compute on one half while PIM attention runs on the other.
 
 ## Sample full trace (single instance, TP=1, dense model)
 
+Reproduced at `_FMT`'s real column widths, so this is byte-for-byte
+what the generator writes (scroll right for the full row):
+
 ```
 COLOCATED		model_parallel_NPU_group: 1
 292
-Layername	comp_time	input_loc	input_size	weight_loc	weight_size	output_loc	output_size	comm_type	comm_size	misc
-embedding_0	5386	REMOTE:0	40	LOCAL	1050673152	LOCAL	81920	NONE	0	NONE
-layernorm_1	2416	LOCAL	81920	LOCAL	8192	LOCAL	81920	NONE	0	NONE
-qkv_proj_2	36000	LOCAL	81920	LOCAL	50331648	LOCAL	122880	NONE	0	NONE
-rotary_emb_3	2795	LOCAL	102400	LOCAL	0	LOCAL	102400	NONE	0	NONE
-attention_4	7985	LOCAL	81920	LOCAL	0	LOCAL	81920	NONE	0	NONE
-o_proj_5	25611	LOCAL	81920	LOCAL	33554432	LOCAL	81920	NONE	0	NONE
-layernorm_6	2416	LOCAL	81920	LOCAL	8192	LOCAL	81920	NONE	0	NONE
-gate_up_proj_7	159157	LOCAL	81920	LOCAL	234881024	LOCAL	573440	NONE	0	NONE
-act_fn_8	2965	LOCAL	573440	LOCAL	0	LOCAL	286720	NONE	0	NONE
+Layername                     comp_time      input_loc      input_size     weight_loc     weight_size    output_loc     output_size    comm_type      comm_size      misc
+embedding_0                   5386           REMOTE:0       40             LOCAL          1050673152     LOCAL          81920          NONE           0              NONE
+layernorm_1                   2416           LOCAL          81920          LOCAL          8192           LOCAL          81920          NONE           0              NONE
+qkv_proj_2                    36000          LOCAL          81920          LOCAL          50331648       LOCAL          122880         NONE           0              NONE
+rotary_emb_3                  2795           LOCAL          102400         LOCAL          0              LOCAL          102400         NONE           0              NONE
+attention_4                   7985           LOCAL          81920          LOCAL          0              LOCAL          81920          NONE           0              NONE
+o_proj_5                      25611          LOCAL          81920          LOCAL          33554432       LOCAL          81920          NONE           0              NONE
 ... (decoder blocks 1..31 elided) ...
-down_proj_288	81014	LOCAL	286720	LOCAL	117440512	LOCAL	81920	NONE	0	NONE
-final_layernorm_289	2624	LOCAL	81920	LOCAL	8192	LOCAL	81920	NONE	0	NONE
-lm_head_290	714006	LOCAL	81920	LOCAL	1050673152	LOCAL	2565120	NONE	0	NONE
-sampler_291	24746	LOCAL	2565120	LOCAL	0	REMOTE:0	40	NONE	0	NONE
+final_layernorm_289           2624           LOCAL          81920          LOCAL          8192           LOCAL          81920          NONE           0              NONE
+lm_head_290                   714006         LOCAL          81920          LOCAL          1050673152     LOCAL          2565120        NONE           0              NONE
+sampler_291                   24746          LOCAL          2565120        LOCAL          0              REMOTE:0       40             NONE           0              NONE
 ```
 
 A layer's `output_size` is **not** in general the next layer's `input_size`:
@@ -224,8 +297,10 @@ ASTRA-Sim.
 1. **`comp_time` is nanoseconds in the trace** but the underlying
    profile CSVs use microseconds. The conversion happens in
    `_load_perf_db()` at simulator startup.
-2. **Tab-separated, not space.** Mixing tabs and spaces breaks the
-   Chakra parser silently.
+2. **Column alignment does not matter.** Both readers split on
+   arbitrary whitespace, so tabs, single spaces, and `_FMT`'s padding
+   are equivalent. What *does* matter is that no field contains a
+   space, since that would read as two fields.
 3. **Don't hand-edit production traces.** They're regenerated every
    iteration; manual edits get clobbered. To inject custom timings,
    modify the profile CSVs or the trace generator.

--- a/docs/docs/simulator/moe-expert-routing.md
+++ b/docs/docs/simulator/moe-expert-routing.md
@@ -109,11 +109,15 @@ also has to know "expert E lives on which rank". This uses **even
 partitioning**:
 
 ```
-rank_for_expert(e) = e * ep_size // num_experts
+GateFunction.expert_owner(e, ep_size, num_experts)
+    = min(e * ep_size // num_experts, ep_size - 1)
 ```
 
 So with 128 experts and `ep_size=2`, experts 0–63 live on rank 0 and
-64–127 on rank 1. With `ep_size=4`, each rank holds 32 experts.
+64–127 on rank 1. With `ep_size=4`, each rank holds 32 experts. The
+`min(..., ep_size - 1)` is defensive — for a valid expert id the
+division already lands below `ep_size` — but it keeps an out-of-range id
+from indexing past the last rank.
 
 The `GateRouter.route()` output collapses per-token assignments into
 per-rank token counts that ASTRA-Sim consumes through the trace's

--- a/docs/docs/simulator/reading-output.md
+++ b/docs/docs/simulator/reading-output.md
@@ -99,138 +99,251 @@ stdout while a run is in progress:
 
 | Level | What you see |
 | --- | --- |
-| `WARNING` (default) | The throughput log line every `--log-interval` seconds, plus warnings (variant fallback, runtime exceeds profiler sweep, MoE config mismatch, etc.) |
-| `INFO` | Adds per-iteration scheduler decisions (which requests entered the batch, prefix-cache hits per request) and the request lifecycle (arrival / first token / completion). Useful for debugging routing and scheduling. |
-| `DEBUG` | Adds per-layer memory load / store activity, full `Batch` / `Request` dumps, and prefix-cache hit-ratio snapshots. Generates a lot of output; pipe to a file. |
+| `WARNING` (default) | The heartbeat block every `--log-interval` seconds, plus warnings (variant fallback, runtime exceeding the profiler sweep, MoE config mismatch, and so on) |
+| `INFO` | Adds per-iteration scheduler detail and request-lifecycle events (resume notices, per-node power logs) |
+| `DEBUG` | Adds per-layer memory load / store activity and full `Batch` / `Request` dumps. Generates a lot of output; pipe to a file |
 
-Independently of the level, the simulator always emits:
+Independently of the level, a run always prints a startup banner, a
+KV-cache sizing block, the periodic heartbeat, and the final results.
+`bench/examples/<model>/outputs/sim.log` holds complete real examples of
+all of it; every sample on this page is copied from there.
 
-- A startup banner with the resolved `(hardware, model, variant)`
-  and the engine_effective comparison vs. `meta.yaml`.
-- The final summary on shutdown (Total requests, mean TTFT / TPOT,
-  throughput, plus the **power summary** below if `power:` is
-  configured).
-
-The throughput log line itself is identical regardless of level,
-the only difference is what surrounds it.
-
-## Throughput log line
-
-Every `--log-interval` seconds the simulator prints a one-line
-status update. The format adapts to which features are enabled:
-
-### Single-instance baseline
+### Startup banner
 
 ```text
-[INFO] step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s npu_mem=88.4 GB
+──────────────────────────── LLMServingSim2.0 ────────────────────────────
+                              Input configuration
+
+  • Cluster config             : bench/examples/configs/Llama-3.1-8B.json
+  • Run ID                     : run_1787203264816023_112338
+  • ASTRA-Sim inputs root      : /app/LLMServingSim/astra-sim/inputs/runs/run_1787203264816023_112338
+  • Dataset                    : workloads/sharegpt-llama-3.1-8b-300-sps10.jsonl
+  • Max num seqs               : 128
+  • Max batched tokens         : 2048
+  • Block size (tokens)        : 16
+  • Request routing            : LOAD
+  • Expert routing             : BALANCED
+  • Prefix caching             : ENABLED
+  • Chunked prefill            : ENABLED
+  • Prefix caching scheme      : xPU-Only
+  • Centralized prefix caching : DISABLED
+  • Offload attention to PIM   : DISABLED
+  • Sub-batch interleaving     : DISABLED
+  • Network backend            : analytical
+  • Log interval (s)           : 1.0
+  • Log level                  : WARNING
+──────────────────────────────────────────────────────────────────────────
+                          KV Cache Initialization
+
+  • Instance [0] : 585248 tokens / 36578 blocks (71.44 GiB/rank at util 0.90)
 ```
+
+The **Run ID** and inputs root are what you need to find a run's
+intermediate ASTRA-Sim files, and they only survive if you passed
+`--no-cleanup-inputs`.
+
+The **KV Cache Initialization** line is the one to read first when
+comparing against real vLLM: it reports the capacity the simulator
+derived from `npu_mem.mem_size * mem_util - weight`. vLLM also
+subtracts its activation peak and CUDA context, which the simulator
+does not model, so this is an upper bound on vLLM's capacity at the
+same utilization. `bench run`'s `meta.json::kv_cache.num_gpu_blocks`
+is the number to compare it against.
+
+Note the banner reports the **CLI** values for `Max num seqs` and
+`Max batched tokens`. Per-instance overrides are not echoed here, so on
+a heterogeneous config this block does not tell you what each instance
+actually got. See
+**[Cluster config → Runtime overrides](/docs/reference/cluster-config#runtime-overrides-optional)**.
+
+## Heartbeat block
+
+Every `--log-interval` simulated seconds the simulator prints a
+throughput line followed by an indented tree, one branch per instance
+and then one per node:
+
+```text
+[1.0s] Avg prompt throughput: 9069.0 tokens/s, Avg generation throughput: 224.0 tokens/s
+        ├─Running Instance[0]: 9 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 16486.51 MB (16.771 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 9069)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
+```
+
+The leading `[1.0s]` is the **simulated** clock, not wall-clock.
 
 | Field | Meaning |
 | --- | --- |
-| `step` | Iteration number this interval ended on |
-| `batch` | Batch size in requests |
-| `prompt_t` | Prompt-side throughput (input tokens/sec, includes prefix hits) |
-| `decode_t` | Decode-side throughput (generated tokens/sec) |
-| `npu_mem` | NPU memory footprint at this moment |
+| `Avg prompt throughput` | Input tokens/s over the interval, **including** prefix-cache hits |
+| `Avg generation throughput` | Generated tokens/s over the interval |
+| `Running Instance[i]` | `len(scheduler.running)` — the persistent running set, not the size of this step's batch. This is the analogue of vLLM's `num_running_reqs`, which is what `bench validate` compares against |
+| `Waiting` | Waiting requests that have already **arrived** (future arrivals are excluded) |
+| `Total # N NPUs` | The instance's `num_npus` |
+| `Each NPU Memory Usage` | Weights plus KV per rank, and that as a percentage of `npu_mem.mem_size` — so the ceiling is `mem_util * 100`, not 100 |
+| `Prefix Cache Hit ratio` | Cumulative since the run started, not per interval, with `(hit tokens / requested tokens)` after it. Present only when the instance has prefix caching on |
+| `Node[i]` | Host memory used by that node's lower KV tier |
 
-### Multi-instance
+### Multiple instances
 
-```text
-[INFO] step=21 inst0_batch=6 inst1_batch=4 prompt_t=2.5k tok/s decode_t=860 tok/s
-       npu_mem=[63.2 GB, 63.2 GB]
-```
-
-`inst0_batch` / `inst1_batch` are per-instance batch sizes; `npu_mem`
-is per-instance.
-
-### Prefill / decode split
+One `├─Running Instance[i]` branch per instance, and the `Node` line
+gains a per-instance split of the host total:
 
 ```text
-[INFO] step=15 P=8 D=12 prompt_t=3.1k tok/s decode_t=620 tok/s
-       npu_mem=[55.4 GB, 71.2 GB]
+[4.0s] Avg prompt throughput: 9063.0 tokens/s, Avg generation throughput: 1074.0 tokens/s
+        ├─Running Instance[0]: 23 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 32634.88 MB (33.198 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 20285)
+        ├─Running Instance[1]: 22 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 32981.38 MB (33.550 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 24147)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used (Instance[0]: 0.00 %, Instance[1]: 0.00 %)
 ```
 
-`P=` and `D=` are batch sizes on the prefill and decode instances.
+The trailing per-instance percentages are each instance's share of the
+node's CPU usage, not of node capacity — they sum to 100% when anything
+is resident. They are omitted when the node has a single instance, and
+also when `--enable-prefix-sharing --prefix-storage CPU` makes the pool
+node-wide rather than per-instance; in that case the `Node` line
+carries a shared `Prefix Cache Hit ratio` instead.
 
-### With prefix sharing
+Nothing in this block identifies which instance is prefill and which is
+decode. Read the instance order from your cluster config.
+
+### With CXL as the lower tier
+
+`--prefix-storage CXL` adds a `CXL` branch after the node lines. With
+`--enable-prefix-sharing` it is one branch per device:
 
 ```text
-[INFO] step=20 inst0_batch=6 inst1_batch=4 prompt_t=2.4k tok/s decode_t=820 tok/s
-       prefix_hit=78% (npu=42%, cpu=36%)
+        ├─CXL[0]: Total CXL Device Memory Usage 3276.80MB, 3.200 % Used
 ```
 
-The `prefix_hit` field shows the cache hit rate across the interval,
-broken down by tier.
-
-### With DP+EP MoE
+and without sharing, one per prefix-caching instance:
 
 ```text
-[INFO] step=8 batch=4+4 prompt_t=1.4k tok/s decode_t=520 tok/s
-       npu_mem=[81.2 GB, 81.2 GB] alltoall=512 KB
+        ├─CXL[0]/Instance[0]: Total CXL Device Memory Usage 3276.80 MB, 3.200 % Used
 ```
 
-`batch=4+4` shows per-DP-member batches. `alltoall` is the
-wave-synchronized ALLTOALL message size.
+### With the power model
 
-### With PIM offload
+A `power:` block on the node appends a final branch:
 
 ```text
-[INFO] step=10 batch=8 prompt_t=1.1k tok/s decode_t=520 tok/s
-       npu_mem=63.4 GB pim_busy=72%
+        └─Avg power consumption: 712.4 W
 ```
 
-`pim_busy` is the fraction of the interval the PIM device was active.
-At ~100% PIM is your bottleneck.
+The label is right and misleading at once. It *is* an average — over the
+log interval, computed as energy accrued since the previous heartbeat
+divided by elapsed simulated time — but it is also a single
+**cluster-wide** figure summed across every node, so on a multi-node run
+this one line cannot be attributed per node. The per-node split appears
+only in the final summary.
 
-### With CXL memory
+## Final results
+
+On shutdown the simulator prints several ruled sections. Trimmed from a
+real 300-request run:
 
 ```text
-[INFO] step=10 batch=4 prompt_t=620 tok/s decode_t=180 tok/s
-       npu_mem=12.4 GB cxl_mem=[3.2 GB, 3.1 GB, 3.1 GB, 3.2 GB]
+▶ Simulation results...
+
+Total simulation time: 0h 2m 40.611s
+─────────────────────────── Throughput Results ───────────────────────────
+Total requests:                                                     300
+Total clocks (ns):                                                  65049871040
+Total latency (s):                                                  65.050
+Total input tokens:                                                 257239
+Total generated tokens:                                             195753
+Request throughput (req/s):                                         4.61
+Average prompt throughput (tok/s):                                  3954.49
+Average generation throughput (tok/s):                              3009.28
+Total token throughput (tok/s):                                     6963.76
+Throughput per 1.0 sec ([prompt_throughput], [gen_throughput]): [(9069.0, 224.0), (13535.0, 493.0), ...]
+──────────────────────── Prefix Caching Results ──────────────────────────
+Total requested prompt tokens:                                      257239
+NPU prefix hit prompt tokens:                                       19520
+NPU prefix hit ratio (%):                                           7.59
+Total prefix hit ratio (%):                                         7.59
+───────────────────────────── Instance [0] ───────────────────────────────
+─────────────────────────── Time to First Token ──────────────────────────
+Mean TTFT (ms):                                                     6915.26
+Median TTFT (ms):                                                   8783.06
+P99 TTFT (ms):                                                      19627.55
+───────────────── Time per Output Token (excl. 1st token) ────────────────
+Mean TPOT (ms):                                                     32.33
+Median TPOT (ms):                                                   33.59
+P99 TPOT (ms):                                                      37.80
+─────────────────────────── Inter-token Latency ──────────────────────────
+Mean ITL (ms) :                                                     32.24
+Median ITL (ms) :                                                   27.68
+P99 ITL (ms) :                                                      111.39
+──────────────────────────────────────────────────────────────────────────
 ```
 
-`cxl_mem` is per-device usage; `npu_mem` drops because weights are
-on CXL.
+Notes on individual fields:
 
-### With power model
+- **`Total simulation time`** is wall-clock: how long the simulation
+  took to run, not the workload's simulated duration. That is
+  `Total latency (s)`.
+- **`Total clocks (ns)`** is the simulated makespan in ASTRA-Sim
+  cycles. Because the simulator is deterministic, this is an exact
+  regression signal — the same config and workload reproduce it
+  bit-for-bit.
+- **`Total input tokens`** is summed from each request's
+  `original_input`, deliberately *not* derived by subtracting the
+  recompute counter. A request preempted again mid-recompute is charged
+  its full remaining work each time it is re-admitted, so the two are
+  not complements.
+- **`Preemptions`** and **`Recomputed prompt tokens (preemption)`**
+  lines appear only when non-zero. Their absence means the run never
+  preempted.
+- **`Throughput per N sec`** is the full per-interval series, the same
+  numbers as the heartbeat lines, as a list of
+  `(prompt, generation)` pairs.
+- The **Prefix Caching Results** block appears only when some instance
+  has prefix caching on. With `--prefix-storage CPU` or `CXL` it gains
+  a `<tier> prefix hit prompt tokens` / `<tier> prefix hit ratio` pair,
+  and `Total prefix hit ratio` covers both tiers.
+- The per-**Instance** blocks report **milliseconds**, unlike the CSV,
+  which is nanoseconds throughout.
+
+:::note TTFT is not measured the way vLLM measures it
+The simulator stops the clock when the first token's *computation*
+completes. vLLM stops it when the client *receives* the token, so real
+vLLM TTFT is higher. `bench validate` puts both sides on matched
+definitions; see **[Bench CLI](/docs/reference/bench-cli)**.
+:::
+
+### Power modeling results
+
+With a `power:` block configured, an extra section lands between
+throughput and the per-instance blocks:
 
 ```text
-[INFO] step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s
-       npu_mem=88.4 GB power=712 W
+──────────────────────── Power Modeling Results ──────────────────────────
+Total energy consumption (kJ):                                      15.95
+──────────────────────────────────────────────────────────────────────────
+Node 0 total energy consumption (kJ):                               15.95
+├─ NPU energy consumption (J):        12453.00
+├─ CPU energy consumption (J):         1233.00
+├─ DRAM energy consumption (J):         442.00
+├─ Link energy consumption (J):         388.00
+└─ ...
+──────────────────────────────────────────────────────────────────────────
+Power per 1.0 sec (W): [712.4, 698.1, ...]
 ```
 
-`power` is the **current** total system power.
-
-## Final power summary
-
-When `--output` is set and the cluster config has a `power:` block,
-the simulator emits a per-node energy breakdown at the end:
-
-```text
-─────── Power summary (node 0) ───────
-   NPU active     :   12,453 J  (78%)
-   NPU standby    :    1,012 J   (6%)
-   NPU idle       :       89 J   (1%)
-   CPU            :    1,233 J   (8%)
-   DRAM           :      442 J   (3%)
-   Link           :      388 J   (2%)
-   Base + NIC + storage : 332 J  (2%)
-   ─────────────────────────────────
-   Total energy   :   15,949 J
-```
-
-For multi-node runs you get one block per node plus a cluster total.
-The breakdown is what makes power numbers actionable for
-energy-efficiency research, you can see which component dominates.
+One node block per node, each listing its per-device energy, followed
+by the full per-interval power series. Per-device figures include that
+device's always-on base power times the run duration, so they sum to
+the node total.
 
 ## Common patterns to look for
 
 ### High waiting count, low NPU memory
 
-The throughput log shows large `batch` counts but `npu_mem` is far
-below the cluster config's `npu_mem.mem_size`. Likely cause: the
-token budget (`--max-num-batched-tokens`) is the bottleneck, not
-memory. Bump it.
+The heartbeat shows a large `Waiting` count while
+`Each NPU Memory Usage` sits well under `mem_util * 100 %`. Likely
+cause: the token budget (`--max-num-batched-tokens`) or
+`--max-num-seqs` is the bottleneck, not memory. Bump whichever binds.
+
+If `Running` is pinned at exactly `--max-num-seqs`, that is the
+binding constraint. If `Running` moves but throughput does not, the
+token budget is.
 
 ### Decode TPOT spikes during prefill bursts
 
@@ -241,14 +354,23 @@ Mitigations:
 - `--enable-chunked-prefill` (default) splits long prefills.
 - `--long-prefill-token-threshold N` caps prefill tokens per
   step.
-- `--npu-memory-utilization` sets how much NPU memory the KV cache
-  gets; lowering it raises memory pressure and therefore preemptions.
+- `--npu-memory-utilization` sets how much NPU memory weights plus
+  KV may use. **Raising** it enlarges the KV cache and admits more
+  concurrent requests; lowering it shrinks capacity and therefore
+  raises preemptions.
 
 ### Prefix hit rate near 0%
 
-Either the workload genuinely has no shared prefixes, or you forgot
-to pre-tokenize. Check that `input_tok_ids` is populated in the
-JSONL (see [Workloads → JSONL format](/docs/workloads/jsonl-format)).
+Either the workload genuinely has no shared prefixes, or it is not
+pre-tokenized. A request with no `input_tok_ids` gets an empty hash
+chain, which disables prefix caching for it outright — so an
+untokenized workload reports exactly 0.00% with the feature enabled.
+Check the JSONL first (see
+[Workloads → JSONL format](/docs/workloads/jsonl-format#why-token-ids-matter)).
+
+Note the heartbeat's ratio is **cumulative** from the start of the run,
+so it climbs slowly and is near zero for the first few intervals even
+on a workload with heavy sharing.
 
 ### MoE per-rank latency varies wildly
 
@@ -265,11 +387,16 @@ decoder block hurts.
 
 ## Validation against known references
 
-LLMServingSim is validated end-to-end against real vLLM with sub-3%
-error on TTFT / TPOT / throughput on the bundled hardware × model
-combos. The validation methodology and per-model results live in
-**[bench/](https://github.com/casys-kaist/LLMServingSim/tree/main/bench)**
-on GitHub.
+LLMServingSim is validated end-to-end against real vLLM. On the three
+bundled configurations, TPOT and end-to-end latency means land within
+1.5%; TTFT means run -2.6% to -5.8%, which is a small absolute
+difference on a metric with small absolute values. Numbers and plots are on
+**[Validation](/docs/validation)**; the harness that produces them is
+**[Bench CLI](/docs/reference/bench-cli)**. Complete real logs for
+those runs are committed under
+**[bench/examples/](https://github.com/casys-kaist/LLMServingSim/tree/main/bench/examples)**,
+which is the best place to see what a healthy run looks like
+end-to-end.
 
 ## What's next
 

--- a/docs/docs/simulator/request-lifecycle.md
+++ b/docs/docs/simulator/request-lifecycle.md
@@ -207,11 +207,18 @@ wave-synchronizing them.
 
 - Updates per-request running totals (cycles spent in this iteration
   attributed to each request based on `q_list`).
-- For requests that finished decoding this step
-  (`request.num_computed_tokens >= request.input + request.output`):
-  records `last_token_time_ns`, computes `latency_ns`, marks done.
-- Returns `(prompt_throughput, decode_throughput, finished_requests)`
-  to the main loop.
+- A token counts as produced when the request has caught up to the
+  length it had already reached (`num_computed_tokens >=
+  num_tokens_reached`), at which point `num_tokens_reached` advances by
+  one. A resumed request recomputing its history stays silent until it
+  gets there, so recomputation is not double-counted as generation.
+- A request is finished when `num_tokens_reached >= request.output`,
+  where `output` is the **total** target length, prompt included. The
+  condition is deliberately *not* on `num_computed_tokens`, which
+  preemption resets to 0 — see
+  **[Continuous batching](./scheduling/continuous-batching)**.
+  `add_latency()` then stamps `end_time` and `latency`.
+- Returns `(prompt_t, gen_t, end_reqs)` to the main loop.
 
 For prefill instances (`pd_type="prefill"`), finished requests are
 **transferred** to a decode instance via

--- a/docs/docs/simulator/scheduling/continuous-batching.md
+++ b/docs/docs/simulator/scheduling/continuous-batching.md
@@ -51,20 +51,60 @@ Details on **[Prefix caching](./prefix-caching)**.
 
 ```mermaid
 flowchart TD
-    START([Iteration start]) --> INIT[remaining_budget = max_num_batched_tokens<br/>batch = []]
-    INIT --> NEXT{More requests<br/>in queue?}
-    NEXT -->|No| RETURN[Return Batch or None]
-    NEXT -->|Yes| CAP{batch size<br/>>= max_num_seqs?}
-    CAP -->|Yes| RETURN
-    CAP -->|No| NEED[Compute needs:<br/>prefill chunk OR decode 1 token]
-    NEED --> MIN[cap = min remaining_budget,<br/>long_prefill_threshold,<br/>tokens_needed]
-    MIN --> CHECKCAP{cap > 0?}
-    CHECKCAP -->|No| NEXT
-    CHECKCAP -->|Yes| MEM{Memory fits<br/>after eviction?}
-    MEM -->|No| NEXT
-    MEM -->|Yes| ADD[Add to batch<br/>budget -= cap]
-    ADD --> NEXT
+    START([Iteration start]) --> PP{pipeline slots<br/>all busy?}
+    PP -->|Yes| NONE([Return None])
+    PP -->|No| INIT["budget = max_num_batched_tokens<br/>scheduled, preempted = empty"]
+
+    INIT --> A1{Phase A: more running<br/>and budget left?}
+    A1 -->|No| GATE{anything<br/>preempted?}
+    A1 -->|Yes| A2["num_new = num_tokens_reached - num_computed_tokens,<br/>capped by budget"]
+    A2 --> A3{num_new<br/>above zero?}
+    A3 -->|"No — a batch is in flight for it"| A1
+    A3 -->|Yes| A4{KV blocks<br/>allocate?}
+    A4 -->|No| A5["Preempt the running tail<br/>(lowest FCFS priority)"]
+    A5 --> A6{victim was<br/>this request?}
+    A6 -->|No| A4
+    A6 -->|Yes| GATE
+    A4 -->|Yes| A7["scheduled += request<br/>budget -= num_new"]
+    A7 --> A1
+
+    GATE -->|"Yes — skip Phase B entirely"| DONE{anything<br/>scheduled?}
+    GATE -->|No| B1{Phase B: waiting non-empty<br/>and budget left?}
+
+    B1 -->|No| DONE
+    B1 -->|Yes| B2{running already at<br/>max_num_seqs?}
+    B2 -->|Yes| DONE
+    B2 -->|No| B3{head request<br/>has arrived?}
+    B3 -->|"No — the queue is arrival-sorted"| DONE
+    B3 -->|Yes| B4["Prefix lookup: NPU blocks,<br/>then lower tiers"]
+    B4 --> B5["num_new = num_tokens - hits, capped by<br/>long_prefill_token_threshold and by budget"]
+    B5 --> B6{chunking off and<br/>chunk over budget?}
+    B6 -->|Yes| DONE
+    B6 -->|No| B7{whole sequence fits?<br/>reserve_full_isl only}
+    B7 -->|No| DONE
+    B7 -->|Yes| B8{KV blocks<br/>allocate?}
+    B8 -->|"No — never preempts to admit"| DONE
+    B8 -->|Yes| B9["Admit: move to running<br/>budget -= num_new"]
+    B9 --> B1
+
+    DONE -->|No| NONE
+    DONE -->|Yes| BATCH([Build Batch])
 ```
+
+Three things about the shape are load-bearing. **Phase B never
+preempts** — every failure path there leaves the loop rather than
+freeing someone else's blocks. **Phase B is skipped entirely on any
+step that preempted**, which is what stops the running set oscillating
+preempt → refill → preempt. And the whole thing is gated on a free
+pipeline slot, so with `pp_size > 1` a step can return `None` purely
+because every stage already has a batch in flight. All three mirror
+vLLM V1's `schedule()`.
+
+Note also what is *not* in the diagram: there is no prefill branch and
+no decode branch. A request simply catches up to `num_tokens_reached`,
+so `num_new` is 1 in steady-state decode and the whole remainder for a
+resumed request. The trace classifies by scheduled token count after
+the fact.
 
 Conceptually, the loop is:
 
@@ -171,17 +211,23 @@ to the next pending arrival time and resumes.
 iteration when ASTRA-Sim reports completion. It returns:
 
 ```python
-(prompt_throughput, decode_throughput, finished_requests)
+(prompt_t, gen_t, end_reqs)
 ```
 
-- `prompt_throughput` counts **all input tokens including prefix
-  cache hits**, matching vLLM's reporting (which also counts cached
-  tokens). `decode_throughput` counts only newly generated tokens.
-- `finished_requests` is the list of requests that completed during
-  this iteration.
+- `prompt_t` counts **all input tokens including prefix cache hits**,
+  matching vLLM's reporting, which also counts cached tokens. The line
+  in `add_done` is literally
+  `prompt_t += num_new + req.prefix_cache_hit`, and it fires once per
+  request, on the step its prefill completes.
+- `gen_t` counts only newly generated tokens, incremented when a
+  request catches up to `num_tokens_reached`. A resumed request
+  recomputing its history contributes nothing here, so recomputation is
+  never counted as generation.
+- `end_reqs` is the list of requests that completed during this
+  iteration.
 
 For prefill instances under P/D disaggregation, the main loop hands
-`finished_requests` to `router.transfer_prefill_request` so the
+`end_reqs` to `router.transfer_prefill_request` so the
 decode instance picks them up.
 
 ## Gotchas

--- a/docs/docs/simulator/scheduling/kv-cache-and-memory.md
+++ b/docs/docs/simulator/scheduling/kv-cache-and-memory.md
@@ -69,10 +69,10 @@ count divided by `tp_size` (and for MoE: experts further divided by
 weight_bytes_per_gpu = (
     dense_params / tp_size
     + moe_params / ep_size  # if MoE
-) * fp_size_in_bytes
+) * fp
 ```
 
-`fp_size` is 2 bytes for `bfloat16` / `float16`, 4 for `float32`,
+`fp` is 2 bytes for `bfloat16` / `float16`, 4 for `float32`,
 1 for `int8` and `fp8`. Actually loading is done via `get_weight()`,
 which reads the model config and accounts for shared embeddings,
 tied weights, etc.
@@ -91,17 +91,29 @@ is `--block-size` tokens (default 16):
 bytes_per_block = (
     2                                         # K and V
     * num_layers
-    * num_key_value_heads / tp_size           # GQA shards by TP
+    * num_key_value_heads
     * head_dim
     * block_size
-    * kv_fp_size
-)
+    * kv_fp
+) / num_npus                                  # = tp_size * pp_size
 ```
 
-Where `kv_fp_size` is:
+The divisor is `num_npus`, i.e. **`tp_size * pp_size`**, not `tp_size`
+alone (`MemoryModel.get_kv()`). Both factors belong there: KV per layer
+shards across TP ranks, and the layers themselves are split across PP
+stages, so a rank in a `tp=2 x pp=2` instance holds a quarter of the
+model's KV, not a half.
 
-- 2 bytes for `--kv-cache-dtype auto` (inherits from `--dtype`).
-- **1 byte for `--kv-cache-dtype fp8`**: halves KV memory.
+Note also that `head_dim` is read explicitly from the model config, not
+derived — see **[Model config](/docs/reference/model-config)**. On Qwen3
+`hidden_size / num_attention_heads` gives the wrong answer.
+
+Where `kv_fp` is:
+
+- 2 bytes for `bfloat16` / `float16` — what `--kv-cache-dtype auto`
+  inherits from `--dtype`; 4 for `float32`.
+- **1 byte for `--kv-cache-dtype fp8`**, which halves KV memory against
+  a 16-bit weight dtype.
 
 How many blocks exist is fixed at startup, the way vLLM sizes its cache:
 
@@ -119,7 +131,7 @@ run prints the resulting figure per instance under **KV Cache
 Initialization** at startup:
 
 ```
-  • Instance [0]                  : 3400 blocks / 54400 tokens (6.64 GiB per rank) at NPU memory utilization 0.90
+  • Instance [0] : 585248 tokens / 36578 blocks (71.44 GiB/rank at util 0.90)
 ```
 
 The scheduler takes `ceil(tokens / block_size)` blocks per active request
@@ -209,28 +221,31 @@ GB of host memory.
 
 ## Reading memory in the throughput log
 
-The throughput log line emitted every `--log-interval` seconds shows
-running memory usage:
+The heartbeat block emitted every `--log-interval` simulated seconds
+carries one branch per instance and then one per node:
 
-```
-[INFO] step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s
-       npu_mem=88.4 GB cpu_mem=12.4 GB
-```
-
-For multi-instance setups it lists per-instance NPU usage:
-
-```
-       npu_mem=[88.4 GB, 87.9 GB] cpu_mem=24.8 GB
+```text
+[1.0s] Avg prompt throughput: 9069.0 tokens/s, Avg generation throughput: 224.0 tokens/s
+        ├─Running Instance[0]: 9 reqs, Waiting: 0 reqs, Total # 1 NPUs, Each NPU Memory Usage 16486.51 MB (16.771 % Used), Prefix Cache Hit ratio 0.00 %, (0 / 9069)
+        └─Node[0]: Total CPU Memory Usage 0.00 MB, 0.000 % Used
 ```
 
-If you're using CXL:
+Reading the memory fields specifically:
 
-```
-       npu_mem=12.4 GB cxl_mem=[3.2 GB, 3.1 GB, 3.1 GB, 3.2 GB]
-```
+- **`Each NPU Memory Usage`** is per rank, in **MB**, and covers weights
+  plus active KV plus indexed prefix blocks — the whole `npu_used`
+  ledger. The percentage is against `npu_mem.mem_size`, so it tops out
+  near `mem_util * 100`, not 100.
+- **`Node[i]: Total CPU Memory Usage`** is the node's lower-tier
+  total. On a multi-instance node it is followed by each instance's
+  share of that total, e.g.
+  `(Instance[0]: 61.20 %, Instance[1]: 38.80 %)`.
+- With `--prefix-storage CXL` a `CXL[...]` branch is added, one per
+  device under `--enable-prefix-sharing` and one per prefix-caching
+  instance otherwise.
 
-(`12.4 GB` is the surviving NPU active KV + cache, with weights now on
-CXL.)
+Full field-by-field reference, including the multi-instance and CXL
+variants: **[Reading the output](/docs/simulator/reading-output#heartbeat-block)**.
 
 ## Gotchas
 
@@ -238,8 +253,8 @@ CXL.)
    error message points at exact byte counts; bump `tp_size` or
    reduce model size.
 2. **OOM mid-run** is unusual but possible if CXL placement is
-   misconfigured. Check the per-device CXL counter in the throughput
-   log.
+   misconfigured. Check the `CXL[...]` branch of the heartbeat block,
+   which appears only with `--prefix-storage CXL`.
 3. **`block_size` matters for memory granularity, not throughput.**
    Smaller blocks = finer accounting but more overhead per request.
    Default 16 is what vLLM uses.

--- a/docs/docs/simulator/scheduling/prefix-caching.md
+++ b/docs/docs/simulator/scheduling/prefix-caching.md
@@ -188,12 +188,17 @@ hit the storage tier at all.
 
 Every iteration's `add_done` call updates these counters:
 
-| Counter | Where |
+| Counter | Where you can actually see it |
 | --- | --- |
-| Per-request `prefix_cache_hit` | per-request CSV `prefix_hit_len` |
-| Per-iteration prompt-throughput hits | throughput log `prefix_hit=...` |
-| Per-instance pool size | throughput log `prefix_pool=...` (when `--enable-prefix-sharing`) |
-| Hit-rate breakdown (NPU vs CPU) | throughput log `prefix_hit=78% (npu=42%, cpu=36%)` |
+| Per-request `prefix_cache_hit` / `npu_cache_hit` / `storage_cache_hit` | **Nowhere in the output.** Tracked on the `Request` object but not written to the per-request CSV. To get at it, read the objects directly or extend `Scheduler.save_output` |
+| Per-instance hit ratio | The heartbeat's instance branch: `Prefix Cache Hit ratio 7.59 %, (19520 / 257239)`. **Cumulative since the run started**, not per interval |
+| Shared lower-tier hit ratio | The same field on the heartbeat's `Node[i]` branch, but only with `--enable-prefix-sharing --prefix-storage CPU`, which makes the pool node-wide |
+| Lower-tier pool occupancy | `Node[i]: Total CPU Memory Usage ...` or the `CXL[...]` branch, in MB and percent |
+| Run totals, split by tier | The final **Prefix Caching Results** section: requested tokens, NPU hit tokens and ratio, the `<tier>` hit tokens and ratio when `--prefix-storage` is set, and the combined total |
+
+There is no per-iteration hit counter and no NPU-versus-CPU breakdown in
+the heartbeat: the per-tier split appears only in the final summary. See
+**[Reading the output](/docs/simulator/reading-output#heartbeat-block)**.
 
 ## Gotchas
 

--- a/docs/docs/simulator/specialized/pim-offload.md
+++ b/docs/docs/simulator/specialized/pim-offload.md
@@ -121,9 +121,13 @@ When PIM offload is on, KV blocks live in PIM memory (per-channel)
 rather than NPU memory. The memory model accounts for this:
 
 - `npu_used` drops by the KV-cache footprint.
-- `pim_used` rises by the same amount.
-- KV evictions go from PIM → CPU (or wherever `kv_evict_loc` is
-  pointing) instead of NPU → CPU.
+- There is **no `pim_used` counter.** `MemoryModel` exposes exactly two
+  ledgers, `npu_used` and `cpu_used`, and PIM-resident KV lands in the
+  latter, since PIM sits in the host memory the node's `cpu_mem`
+  describes. The heartbeat's `Node[i]: Total CPU Memory Usage` line is
+  where it shows up.
+- KV evictions go from PIM → wherever `kv_evict_loc` points, instead of
+  NPU → CPU.
 
 This is what makes PIM offload memory-attractive for long-context
 workloads: the GPU's HBM is freed up to hold larger weights or more
@@ -144,20 +148,25 @@ The standard fix is **sub-batch interleaving**: overlap GPU compute
 on one half of the batch with PIM attention on the other half. See
 [Examples → Sub-batch interleaving](/docs/examples/advanced/sub-batch-interleaving).
 
-## Throughput log additions
+## What PIM offload does *not* add to the log
 
-When PIM is active, the throughput log gains a `pim_busy=` field per
-node:
+Nothing. The heartbeat block is identical with and without
+`--enable-attn-offloading` — there is no PIM utilization or busy-fraction
+counter anywhere in the simulator.
 
-```
-[INFO] step=10 batch=8 prompt_t=1.1k tok/s decode_t=520 tok/s
-       npu_mem=63.4 GB pim_busy=72%
-```
+Offloading works by substituting PIM attention for the NPU attention
+kernel inside the generated trace, so its effect is visible as changed
+generation throughput and TPOT rather than as a new field. To attribute
+a slowdown to PIM:
 
-`pim_busy` is the fraction of simulated time the PIM device was
-running attention work in the last log interval. When this saturates
-near 100%, PIM is your bottleneck, try multi-channel PIM, or revert
-to NPU attention for prefill-heavy phases.
+- Run the same workload with and without `--enable-attn-offloading` and
+  compare TPOT.
+- Pass `--no-cleanup-inputs` and read the emitted trace: PIM work sits
+  between `PIM <channel>` and `PIM END` markers, with its own
+  `comp_time`.
+- Widen the node's `cpu_mem.mem_size` to buy more PIM channels — channel
+  count is derived from it, not declared. See
+  **[PIM config](/docs/reference/pim-config#how-the-numbers-are-derived)**.
 
 ## Gotchas
 

--- a/docs/docs/simulator/specialized/power-model.md
+++ b/docs/docs/simulator/specialized/power-model.md
@@ -45,8 +45,12 @@ total_energy += ΔE
 The trick is **per-component tracking**. NPU power depends on
 whether it's actively running a kernel (active_power), recently
 finished (standby_power for `standby_duration` ns, then back to
-idle), or idle. The model tracks `last_compute_end_ns` per NPU and
-applies the right wattage based on `current_ns - last_compute_end_ns`.
+idle), or idle. There is no stored `last_compute_end_ns` field: the
+trace generator passes the boundaries in per call, as
+`add_npu_standby_energy_consumption(hardware, node_id, current_ns,
+last_end_ns, last_calc_ns, num_npus)`, and the model derives the
+standby window from `current_ns - last_end_ns` against that hardware's
+configured `standby_duration`, clamping to zero once it is spent.
 
 CPU, DRAM, link, NIC, storage are simpler: each has a constant
 background draw plus a per-event energy increment for traffic /
@@ -86,16 +90,18 @@ state workloads where the NPU is more or less always busy.
 
 ### Periodic throughput log
 
-Every `--log-interval` seconds, the throughput log line gains a
-`power=` field:
+Every `--log-interval` simulated seconds, the heartbeat block gains a
+final branch:
 
-```
-[INFO] step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s
-       npu_mem=88.4 GB power=712 W
+```text
+        └─Avg power consumption: 712.4 W
 ```
 
-`power` is the **current** total system power, the sum of every
-component's instantaneous wattage at this moment.
+Despite reading like a snapshot, this is the **interval average**:
+`get_current_power()` takes the energy accrued since the previous
+heartbeat and divides by the elapsed simulated time. It also sums
+across **every node** into one scalar, so it is a cluster figure, not a
+per-node one.
 
 ### Final summary
 
@@ -122,14 +128,12 @@ see which components dominate.
 ## Multi-node power
 
 Each node has its own `power:` block. The simulator runs all node
-power models in parallel and the throughput log line shows them
-together:
-
-```
-       power=[node0=712 W, node1=689 W]
-```
-
-The final summary prints a per-node breakdown plus a cluster total.
+power models in parallel, but the heartbeat still prints **one**
+aggregated number — `get_current_power()` accumulates across nodes
+before returning. Per-node attribution is available only in the final
+summary, which prints a `Node <i> total energy consumption (kJ)` block
+per node with a per-device breakdown under it, plus the cluster total
+and the full per-interval power series.
 
 ## Where the per-NPU active power comes from
 

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -38,14 +38,31 @@ configurations:
 
 | Model | Parallelism | TTFT mean | TPOT mean | Latency mean |
 | --- | --- | --- | --- | --- |
-| Llama-3.1-8B                | TP=1 dense       | -0.3% | +0.7% | +0.4% |
-| Qwen3-32B                   | TP=2 dense       | +2.4% | +1.7% | +2.0% |
-| Qwen3-30B-A3B-Instruct-2507 | DP=2 × EP=2 MoE  | -1.5% | +1.1% | +0.9% |
+| Llama-3.1-8B                | TP=1 dense       | -2.6% | -0.4% | -1.0% |
+| Qwen3-32B                   | TP=2 dense       | +1.8% | +1.2% | +1.5% |
+| Qwen3-30B-A3B-Instruct-2507 | DP=2 x EP=2 MoE  | -5.8% | -0.2% | -0.4% |
 
-Across all three, **TTFT / TPOT / latency means stay within ~2.5%
-of vLLM**, and the DP+EP MoE path tracks vLLM as tightly as the
-dense TP path. Per-percentile numbers (P50 / P90 / P95 / P99) are in
-the per-model `summary.txt` files under
+Every number on this page is read out of the committed
+`bench/examples/<model>/validation/summary.txt` files, so it is
+reproducible rather than quoted.
+
+**TPOT and end-to-end latency means land within 1.5% on all three
+configurations**, and the DP+EP MoE path tracks vLLM as tightly as the
+dense TP path on both. TTFT means are looser: -2.6% on Llama and -5.8%
+on the MoE run.
+
+That TTFT spread is expected rather than alarming, and it is worth
+knowing why before reading the tables. The two sides do not define the
+measurement identically — the simulator stops the clock when the first
+token's *computation* finishes, vLLM when the client *receives* it — and
+TTFT is dominated by queueing, so a small scheduling difference early in
+the run moves the mean a lot. On the MoE run the median TTFT is 139 ms
+against 111 ms, so a 28 ms absolute difference reads as -20%. Judge
+TTFT by its absolute error and its tail, not by percentage of a very
+small number: P90 through P99 land within 5.4% on every configuration.
+
+Per-percentile numbers (median / P90 / P95 / P99) are in the same
+`summary.txt` files under
 [`bench/examples/`](https://github.com/casys-kaist/LLMServingSim/tree/main/bench/examples).
 
 ## Per-model results
@@ -60,16 +77,18 @@ Headline error vs. vLLM:
 
 | Metric | vLLM | Sim | Diff |
 | --- | --- | --- | --- |
-| TTFT mean    |  7.10 s   |  7.07 s   | **-0.3%** |
-| TTFT P99     | 19.76 s   | 19.96 s   | +1.0% |
-| TPOT mean    | 32.5 ms   | 32.7 ms   | **+0.7%** |
-| TPOT P99     | 37.3 ms   | 38.1 ms   | +2.1% |
-| Latency mean | 28.20 s   | 28.31 s   | **+0.4%** |
-| Latency P99  | 37.64 s   | 37.96 s   | +0.8% |
+| TTFT mean     |    7.10 s |    6.92 s | **-2.6%** |
+| TTFT P99      |   19.76 s |   19.63 s | -0.6% |
+| TPOT mean     |   32.5 ms |   32.3 ms | **-0.4%** |
+| TPOT P99      |   37.3 ms |   37.8 ms | +1.2% |
+| Latency mean  |   28.20 s |   27.92 s | **-1.0%** |
+| Latency P99   |   37.64 s |   37.38 s | -0.7% |
 
-Single-instance dense Llama is the simplest configuration. The
-simulator matches TTFT mean to within 0.3% and tracks TPOT and
-end-to-end latency within ~1%.
+Single-instance dense Llama is the simplest configuration, and the
+tightest: TPOT within 0.4% and end-to-end latency within 1.0% at every
+percentile. TTFT mean is -2.6%, and its median -7.0% — the simulator
+gets first tokens out slightly early, which matters proportionally more
+on the metric with the smallest absolute values.
 
 ### Qwen3-32B (TP=2 dense)
 
@@ -81,17 +100,20 @@ Headline error vs. vLLM:
 
 | Metric | vLLM | Sim | Diff |
 | --- | --- | --- | --- |
-| TTFT mean    | 36.91 s    | 37.81 s    | **+2.4%** |
-| TTFT P99     | 93.35 s    | 95.25 s    | +2.0% |
-| TPOT mean    |  80.3 ms   |  81.7 ms   | **+1.7%** |
-| TPOT P99     |  97.1 ms   |  99.2 ms   | +2.2% |
-| Latency mean | 90.41 s    | 92.23 s    | **+2.0%** |
-| Latency P99  | 126.34 s   | 129.30 s   | +2.3% |
+| TTFT mean     |   36.91 s |   37.59 s | **+1.8%** |
+| TTFT P99      |   93.35 s |   94.68 s | +1.4% |
+| TPOT mean     |   80.3 ms |   81.3 ms | **+1.2%** |
+| TPOT P99      |   97.1 ms |   98.8 ms | +1.8% |
+| Latency mean  |   90.41 s |   91.73 s | **+1.5%** |
+| Latency P99   |  126.34 s |  128.45 s | +1.7% |
 
 TP=2 exercises the dense ALLREDUCE collective on `o_proj` /
-`down_proj`. Means and P99s land within ~2.5%; the simulator
-slightly over-predicts because per-iteration dense compute now
-accounts for chunked-prefill token counts more aggressively.
+`down_proj`. This is the most uniformly accurate of the three: every
+metric at every percentile lands between +1.2% and +2.3%, and every one
+of them is positive — the simulator consistently over-predicts by a
+little rather than scattering. A systematic bias of that shape points at
+a small fixed per-iteration overhead, not at a modelling error in any
+one component.
 
 ### Qwen3-30B-A3B-Instruct-2507 (DP=2 × EP=2 MoE)
 
@@ -103,18 +125,24 @@ Headline error vs. vLLM:
 
 | Metric | vLLM | Sim | Diff |
 | --- | --- | --- | --- |
-| TTFT mean    |  1.09 s    |  1.07 s    | **-1.5%** |
-| TTFT P99     |  9.59 s    | 10.04 s    | +4.7% |
-| TPOT mean    | 47.3 ms    | 47.8 ms    | **+1.1%** |
-| TPOT P99     | 53.3 ms    | 54.7 ms    | +2.7% |
-| Latency mean | 32.34 s    | 32.64 s    | **+0.9%** |
-| Latency P99  | 43.90 s    | 44.26 s    | +0.8% |
+| TTFT mean     |    1.09 s |    1.02 s | **-5.8%** |
+| TTFT P99      |    9.59 s |   10.10 s | +5.4% |
+| TPOT mean     |   47.3 ms |   47.2 ms | **-0.2%** |
+| TPOT P99      |   53.3 ms |   54.0 ms | +1.4% |
+| Latency mean  |   32.34 s |   32.22 s | **-0.4%** |
+| Latency P99   |   43.90 s |   43.73 s | -0.4% |
 
 This is the disaggregated path: data-parallel across two instances,
-expert-parallel within each instance, with wave-synchronized
-ALLTOALL on the 2D ASTRA-Sim topology. TTFT P50 is noisier (the
-simulator finishes very short prefills slightly faster), but means
-and tail latencies align with vLLM within ~3%.
+expert-parallel within each instance, with wave-synchronized ALLTOALL
+on the 2D ASTRA-Sim topology. TPOT and latency are the best of the
+three — within 0.2% and 0.4% on the mean, and within 1.4% at P99.
+
+TTFT is the outlier at -5.8% on the mean and -19.9% on the median, and
+the absolute numbers explain it: the median is 139 ms against 111 ms, a
+28 ms difference. This workload arrives at 0.2 sessions/s, so most
+prefills are scheduled immediately and TTFT is nearly pure compute with
+almost no queueing to average over. The tail, where queueing does
+appear, lands within 5.4%.
 
 ## Reproducing locally
 

--- a/docs/docs/workloads/agentic-sessions.md
+++ b/docs/docs/workloads/agentic-sessions.md
@@ -94,10 +94,10 @@ python -m serving \
   --dtype bfloat16 --block-size 16 \
   --dataset 'workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl' \
   --output 'outputs/swebench_run.csv' \
-  --num-req 1
+  --num-reqs 1
 ```
 
-`--num-req 1` means one *session* (which expands to 8-15
+`--num-reqs 1` means one *session* (which expands to 8-15
 sub-requests). Bump it for longer runs.
 
 ## Building your own agentic workload
@@ -182,17 +182,25 @@ with agentic sessions.
 
 ## Gotchas
 
-1. **Last sub-request's `tool_duration_ns` should be 0** (or just
-   omitted in your generator if you treat 0 as default). Non-zero
-   keeps the session "alive" past its real end and the simulator
-   waits unnecessarily.
+1. **The last sub-request's `tool_duration_ns` is ignored.** It is
+   read, but `notify_request_completed` only uses the release time when
+   there is a next sub-request; on the last one it deletes the session
+   and discards the value. A non-zero tail does **not** keep the
+   session alive or make the simulator wait. Setting it to `0` is
+   convention, not a requirement — and the field is optional anywhere
+   in the chain, defaulting to `0`.
 2. **Session arrival_time_ns is for the *first* sub-request.**
    Subsequent sub-requests have their arrival times computed at run
    time as `previous_completion + tool_duration_ns`.
-3. **Pre-tokenize for prefix caching.** Agentic sessions usually have
-   *very* high prefix overlap between sub-requests (each call shares
-   the system prompt + previous turns). Without
-   `input_tok_ids`, you lose the bulk of the savings.
+3. **Pre-tokenize for prefix caching, and include the outputs.**
+   Agentic sessions have *very* high prefix overlap between
+   sub-requests, since each call carries the system prompt plus every
+   previous turn. Without `input_tok_ids` a request gets an empty hash
+   chain, which disables prefix caching for it outright — not a coarser
+   match, zero hits. And because turn N+1's prompt contains turn N's
+   *output*, `output_tok_ids` are what make the cross-turn reuse
+   visible; the chain is built over `input_hash_ids + output_hash_ids`.
+   See **[JSONL format → Why token IDs matter](./jsonl-format#why-token-ids-matter)**.
 4. **Sessions are scheduled to whichever instance is least loaded
    at the time of *each* sub-request's release.** A long agent run
    could hop between instances in a multi-instance config. If you

--- a/docs/docs/workloads/jsonl-format.md
+++ b/docs/docs/workloads/jsonl-format.md
@@ -26,11 +26,19 @@ Every line is one independent request:
 | `input_toks` | int | ✓ | Number of prompt tokens |
 | `output_toks` | int | ✓ | Number of tokens to generate |
 | `arrival_time_ns` | int | ✓ | When the request arrives in nanoseconds (relative to start of simulation) |
-| `input_tok_ids` | list&lt;int&gt; | optional | Pre-tokenized prompt IDs (enables prefix-cache hashing, see [below](#why-token-ids-matter)) |
-| `output_tok_ids` | list&lt;int&gt; | optional | Pre-tokenized output IDs (used internally for output-side analysis; usually fine to omit) |
+| `input_tok_ids` | list&lt;int&gt; | optional | Pre-tokenized prompt IDs. **Without these, prefix caching is disabled for the request**, see [below](#why-token-ids-matter) |
+| `output_tok_ids` | list&lt;int&gt; | optional | Pre-tokenized output IDs. Appended to the same hash chain, so generated tokens become cacheable blocks |
 
-If `input_tok_ids` is provided, `len(input_tok_ids)` must equal
-`input_toks` (same for output).
+Both are read only when prefix caching is on for the receiving
+instance; with `--no-enable-prefix-caching` they are ignored entirely.
+
+Nothing checks that `len(input_tok_ids) == input_toks`. The two are
+used for different things — `input_toks` drives scheduling and KV
+sizing, the ids drive only block hashing — so a mismatch does not
+raise. It silently changes how many blocks get hashed: the chain covers
+`floor(len(ids) / block_size)` blocks, so ids shorter than `input_toks`
+leave the tail of the prompt uncacheable, and longer ids hash blocks
+the request never computes.
 
 ### When to use flat
 
@@ -61,9 +69,9 @@ this dependency chain:
 
 | Field | Type | Required | Meaning |
 | --- | --- | --- | --- |
-| `session_id` | string | ✓ | Unique identifier for the session |
+| `session_id` | string | optional | Identifier used to key the dependency chain. Defaults to `session_<n>` derived from the running request id. Supply it when you want the value to be stable and meaningful |
 | `arrival_time_ns` | int | ✓ | When the **first** sub-request arrives |
-| `sub_requests` | list&lt;object&gt; | ✓ | Ordered chain of LLM calls. Length ≥ 1 |
+| `sub_requests` | list&lt;object&gt; | ✓ | Ordered chain of LLM calls. An empty list is **silently skipped** — the line contributes no requests and raises nothing |
 
 ### Sub-request fields
 
@@ -71,12 +79,13 @@ this dependency chain:
 | --- | --- | --- | --- |
 | `input_toks` | int | ✓ | Prompt tokens for this LLM call |
 | `output_toks` | int | ✓ | Generated tokens |
-| `tool_duration_ns` | int | ✓ | Time to wait **after** this call completes before the next sub-request becomes eligible |
+| `tool_duration_ns` | int | optional (default `0`) | Time to wait **after** this call completes before the next sub-request becomes eligible. Read with `.get(..., 0)`, so omitting it means the next call is released immediately |
 | `input_tok_ids` | list&lt;int&gt; | optional | Same as flat format |
 | `output_tok_ids` | list&lt;int&gt; | optional | Same as flat format |
 
-The last sub-request typically has `tool_duration_ns: 0` (nothing to
-wait for after the session ends).
+The last sub-request's `tool_duration_ns` is read but has no effect —
+there is no next call to release — so setting it to `0` is convention
+rather than a requirement.
 
 ### When to use agentic
 
@@ -122,26 +131,59 @@ If your dataset only has raw text, you have two options:
 
 1. Run a tokenizer at workload-generation time to populate
    `input_tok_ids`. The ShareGPT generator does this.
-2. Skip token IDs entirely. Prefix caching still works for *exact*
-   prefix matches based on `input_toks` alone, but matches are much
-   coarser and miss most opportunities.
+2. Skip token IDs entirely and accept **zero** prefix-cache hits.
+
+Option 2 is not a graceful degradation. `request_block_hashes()`
+returns an empty chain for a request with no `input_hash_ids`, which
+turns prefix caching off for that request while leaving allocation
+untouched. There is no coarser fallback keyed on `input_toks`: the
+index is keyed on block hashes, and a request with no hashes never
+matches and is never inserted. A run can therefore have
+`--enable-prefix-caching` on and report a 0% hit rate purely because
+the workload has no token ids.
+
+### `output_tok_ids` are not decorative
+
+The chain is built over `input_hash_ids + output_hash_ids`, so
+generated tokens become cacheable blocks too. That is what lets turn
+N+1 of a session hit on turn N's output, which is most of the reuse in
+an agentic or multi-turn workload. Omit them and you keep prompt-side
+reuse but lose the cross-turn kind.
+
+The simulator can build the whole chain up front because it knows the
+full sequence in advance, unlike vLLM which extends the chain per
+emitted token. That is not future information reaching the scheduler:
+every read into the chain is gated by `num_computed_tokens`, so a block
+only becomes insertable once its tokens have actually been computed.
 
 **Tokenize with the same model the simulator runs.** A workload
 generated with the Llama tokenizer won't produce useful prefix hits
 in a Qwen3 simulation, the token streams are entirely different.
 
-## Validation
+## What the loader does and does not check
 
-The loader (`router.load_requests`) checks at startup:
+`router.load_requests()` is deliberately thin. It reads each line with
+`json.loads`, dispatches on the presence of `sub_requests`, and indexes
+the fields it needs directly. There is **no validation pass**, and no
+line-numbered error reporting.
 
-- All required fields present.
-- `len(input_tok_ids) == input_toks` if provided (same for output).
-- `arrival_time_ns >= 0` and any order is fine, the loader sorts
-  by arrival time anyway.
-- Agentic: at least one sub-request, `tool_duration_ns >= 0`.
+What that means in practice:
 
-Validation errors are printed with the offending line number and
-field name; the loader exits before any simulation work starts.
+| Malformed input | What happens |
+| --- | --- |
+| Missing `input_toks` / `output_toks` / `arrival_time_ns` | `KeyError` on that field, with a bare traceback and no line number |
+| Non-integer token counts | `int()` coerces silently where it can (`"133"` works, `13.7` truncates), raises `ValueError` otherwise |
+| `len(input_tok_ids) != input_toks` | Accepted. Changes only how much of the prompt is hashable |
+| Negative `arrival_time_ns` | Accepted. The request sorts to the front and is routed on the first iteration |
+| Empty `sub_requests` | Line skipped silently, contributing no requests |
+| Duplicate `session_id` | The later session **overwrites** the earlier one in `_deferred_sessions`. Completions from *either* session then release the later session's sub-requests, so the earlier chain never advances and the later one is driven twice |
+
+Arrival order in the file does not matter: the loader sorts
+`_pending_requests` by `arrival_time_ns` after reading everything, which
+is also what lets flat and agentic lines interleave correctly.
+
+If you are generating workloads programmatically, validate on the
+writing side. The bundled generator does.
 
 ## Gotchas
 
@@ -151,9 +193,9 @@ field name; the loader exits before any simulation work starts.
    real seconds.
 2. **Token IDs are integers, not strings.** Whatever your tokenizer
    outputs (`tokenizer.encode(...).ids`) goes here directly.
-3. **Output token IDs are usually unused at runtime**: the simulator
-   doesn't need them to compute decode timing. Provided generators
-   include them for downstream analysis tools.
+3. **Output token IDs are used at runtime.** They are not needed for
+   decode *timing*, which comes from token counts, but they extend the
+   prefix-cache hash chain. Dropping them costs cross-turn hits.
 4. **Mixing tokenizers across workloads is fine, but mixing inside
    one file is not.** All `input_tok_ids` should come from the same
    tokenizer.

--- a/docs/docs/workloads/overview.mdx
+++ b/docs/docs/workloads/overview.mdx
@@ -53,7 +53,7 @@ hardware × model combinations. Drop them straight into
 | `sharegpt-llama-3.1-8b-300-sps10.jsonl` | flat | `meta-llama/Llama-3.1-8B` | ShareGPT, 300 requests at 10 sessions/s |
 | `sharegpt-qwen3-32b-300-sps10.jsonl` | flat | `Qwen/Qwen3-32B` | ShareGPT, dense Qwen3 |
 | `sharegpt-qwen3-30b-a3b-300-sps10.jsonl` | flat | `Qwen/Qwen3-30B-A3B-Instruct-2507` | ShareGPT, MoE Qwen3 |
-| `swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl` | agentic | `Qwen/Qwen3-30B-A3B-Instruct-2507` | 50 SWE-bench sessions, low arrival rate |
+| `swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl` | agentic | `Qwen/Qwen3-30B-A3B-Instruct-2507` | 50 SWE-bench sessions, low arrival rate. **No generator ships for this one** — `workloads.generators` has only the `sharegpt` subcommand, so an agentic workload of your own means emitting the JSONL directly (see [Agentic sessions](./agentic-sessions)) |
 
 Token IDs in these files are pre-tokenized with the matching model's
 tokenizer, so prefix caching works correctly out of the box. Using a

--- a/docs/docs/workloads/sharegpt-generators.md
+++ b/docs/docs/workloads/sharegpt-generators.md
@@ -56,6 +56,7 @@ the container, see
 | --- | --- | --- |
 | `--model` | (required) | HuggingFace model id; used for tokenization (and optionally free-generation) |
 | `--source` | `shibing624/sharegpt_gpt4` | HF dataset id or local path. Any dataset with `conversations` field works |
+| `--output` | (required) | Output JSONL path |
 
 ### Sampling
 
@@ -122,8 +123,27 @@ matching the model you'll run in the simulator:
 | Flag | Default | Meaning |
 | --- | --- | --- |
 | `--use-vllm` | off | Use vLLM to free-generate outputs |
-| `--vllm-tp` | `1` | TP degree for vLLM |
+| `--vllm-tp` | `1` | `tensor_parallel_size` for the offline engine |
 | `--vllm-dtype` | `bfloat16` | vLLM weight dtype |
+| `--vllm-max-num-seqs` | `1024` | `max_num_seqs`. Deliberately high — this is a throughput job, not a latency measurement |
+| `--vllm-max-num-batched-tokens` | `16384` | `max_num_batched_tokens`, likewise high for throughput |
+| `--vllm-max-model-len` | model's max | Override `max_model_len` |
+| `--vllm-temperature` | `0.0` | Sampling temperature. `0` = greedy, which makes generation reproducible for a given seed |
+| `--vllm-repetition-penalty` | `1.1` | Down-weights already-emitted tokens. `1.0` disables it |
+
+:::note Why the repetition penalty defaults above 1.0
+Free generation at `1.0` tends to ramble past the natural stopping
+point, so EOS never fires and every request runs to
+`--max-output-toks`. `1.1` keeps natural EOS landing at typical
+ShareGPT lengths (~500–1000 tokens), which is what makes the resulting
+output-length distribution look like the real dataset's.
+:::
+
+The five `--vllm-*` engine knobs above are throughput settings for the
+generation job itself. They have **no** bearing on the simulated run:
+the generator only records token counts and ids, so `--vllm-max-num-seqs
+1024` here does not mean the workload should be simulated at
+`--max-num-seqs 1024`.
 
 With `--use-vllm`:
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -132,6 +132,7 @@ const sidebars: SidebarsConfig = {
         'reference/model-config',
         'reference/pim-config',
         'reference/trace-format',
+        'reference/bench-cli',
       ],
     },
     'artifact-evaluation',

--- a/profiler/README.md
+++ b/profiler/README.md
@@ -297,8 +297,16 @@ t_skew   — the actual skewed batch [nb × kv_big, (n-nb) × kvs]
 From these three we get a normalised alpha per case:
 
 ```
-alpha = (t_skew - t_mean) / (t_max - t_mean) ∈ [0, 1]
+alpha = (t_skew - t_mean) / (t_max - t_mean)
 ```
+
+Nothing clamps this ratio, and the measured data does leave `[0, 1]`:
+across the bundles in `perf/`, 14-20% of rows are negative (the
+endpoint gap sitting inside measurement noise) and 2-5% exceed 1 (a
+skewed mix genuinely costing more than uniform-max, since tile padding
+and SM imbalance are not bounded by it). p50 is 0.07-0.13, p90 is
+0.46-0.96. Rows where `t_max <= t_mean` are recorded as `nan` and
+dropped by the fit.
 
 which the simulator then applies at query time:
 
@@ -369,7 +377,9 @@ them from there.
 ### Disabling / re-fitting
 
 - Set `SKIP_SKEW=1` to skip the sweep entirely (uniform attention
-  grid only; simulator will use the module-level fallback alpha).
+  grid only). The simulator's fallback constant is **0**, so it then
+  applies no skew correction at all and returns `t_mean` -- it does
+  not borrow an alpha from another GPU.
 - Set `ONLY_SKEW=1` to skip every other category and refresh just
   `skew.csv` + `skew_fit.csv` — useful after widening the grid or
   tweaking factors.

--- a/profiler/core/skew.py
+++ b/profiler/core/skew.py
@@ -10,7 +10,7 @@ skew case measures three latencies at the same operating point:
 
 From these we can compute the normalized interpolation factor
 
-    alpha = (t_skew - t_mean) / (t_max - t_mean)    ∈ [0, 1]
+    alpha = (t_skew - t_mean) / (t_max - t_mean)
 
 which the simulator uses at query time:
 

--- a/profiler/profile-all.sh
+++ b/profiler/profile-all.sh
@@ -5,7 +5,7 @@
 #
 #     ./profiler/profile-all.sh
 #
-# Each run writes to perf/<HARDWARE>/<MODEL>/<variant>/tp{1,2}/ — see
+# Each run writes to profiler/perf/<HARDWARE>/<MODEL>/<variant>/tp{1,2}/ — see
 # ./profiler/profile.sh for the single-model equivalent.
 # -----------------------------------------------------------------------------
 
@@ -57,7 +57,7 @@ for MODEL in "${MODELS[@]}"; do
 done
 
 echo
-echo "All profiles done. Output under perf/$HARDWARE/:"
+echo "All profiles done. Output under profiler/perf/$HARDWARE/:"
 for MODEL in "${MODELS[@]}"; do
-    echo "  perf/$HARDWARE/$MODEL/"
+    echo "  profiler/perf/$HARDWARE/$MODEL/"
 done

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -330,7 +330,9 @@ def main():
     parser.add_argument('--log-level', type=str, choices=['WARNING', 'INFO', 'DEBUG'], default='WARNING',
                         help='logging verbosity: WARNING (minimal), INFO (per-iteration details), DEBUG (per-layer memory)')
     parser.add_argument('--kv-cache-dtype', type=str, choices=['auto', 'fp8'], default='auto',
-                        help='KV cache data type: auto (use default profile.csv) or fp8 (use profile_fp8.csv, halves KV cache memory)')
+                        help='KV cache data type: auto (inherit --dtype) or fp8. Selects the profile '
+                        'variant folder -- fp8 resolves to <dtype>-kvfp8, e.g. bf16-kvfp8 -- and '
+                        'halves KV cache memory. Override per instance with "kv_cache_dtype"')
     parser.add_argument('--network-backend', type=str, choices=['analytical', 'ns3'], default='analytical',
                         help='network simulation backend: analytical (fast, default) or ns3 (detailed, WIP)')
 

--- a/serving/run.sh
+++ b/serving/run.sh
@@ -4,75 +4,75 @@
 python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
     --dtype bfloat16 --block-size 16 \
     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_single_run.csv' \
-    --num-req 10
+    --num-reqs 10
 
 # Multi instance example
 # python -m serving --cluster-config 'configs/cluster/single_node_multi_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_multi_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # PD example
 # python -m serving --cluster-config 'configs/cluster/single_node_pd_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pd_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # CXL example
 # python -m serving --cluster-config 'configs/cluster/single_node_cxl_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_cxl_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # Prefix cache with CPU Prefix Cache Pool example (Single Node)
 # python -m serving --cluster-config 'configs/cluster/single_node_multi_instance.json' \
 #      --dtype bfloat16 --block-size 16 \
 #     --enable-prefix-caching --enable-prefix-sharing --prefix-storage CPU \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_prefix_cpu_mem_pool_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # Prefix cache with CPU Prefix Cache Pool example (Dual Node)
 # python -m serving --cluster-config 'configs/cluster/dual_node_multi_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --enable-prefix-caching --enable-prefix-sharing --prefix-storage CPU \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_dual_prefix_cpu_mem_pool_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # Power model example
 # python -m serving --cluster-config 'configs/cluster/single_node_power_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_power_run.csv' \
-#     --num-req 10 --log-interval 0.1
+#     --num-reqs 10 --log-interval 0.1
 
 # # PIM example
 # python -m serving --cluster-config 'configs/cluster/single_node_pim_instance.json' \
 #     --dtype bfloat16 --block-size 16 --enable-attn-offloading \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pim_run.csv' \
-#     --num-req 10 --log-level WARNING
+#     --num-reqs 10 --log-level WARNING
 
 # # Sub-batch interleaving example
 # python -m serving --cluster-config 'configs/cluster/single_node_pim_instance.json' \
 #     --dtype bfloat16 --block-size 16 --enable-attn-offloading --enable-sub-batch-interleaving \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pim_sub_batch_run.csv' \
-#     --num-req 10 --log-level WARNING
+#     --num-reqs 10 --log-level WARNING
 
 # # Pipeline parallelism example (4 GPUs as pp=4, one stage each)
 # python -m serving --cluster-config 'configs/cluster/single_node_pp_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_pp_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # Tensor + pipeline parallelism example (4 GPUs as tp=2 x pp=2)
 # python -m serving --cluster-config 'configs/cluster/single_node_tp_pp_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_tp_pp_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # # MoE with tensor + pipeline + expert parallelism (4 GPUs as tp=2 x pp=2, ep=2)
 # python -m serving --cluster-config 'configs/cluster/single_node_moe_pp_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_moe_pp_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 
 
@@ -80,13 +80,13 @@ python -m serving --cluster-config 'configs/cluster/single_node_single_instance.
 # python -m serving --cluster-config 'configs/cluster/single_node_moe_single_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_moe_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # MoE DP+EP with agentic session example (SWE-bench)
 # python -m serving --cluster-config 'configs/cluster/single_node_moe_dp_ep_instance.json' \
 #     --dtype bfloat16 --block-size 16 \
 #     --dataset 'workloads/swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl' --output 'outputs/example_moe_dp_ep_run.csv' \
-#     --num-req 1 # session count in agentic workload
+#     --num-reqs 1 # session count in agentic workload
 
 
 # -----------------------------------------------------------------------------------------------
@@ -98,11 +98,11 @@ python -m serving --cluster-config 'configs/cluster/single_node_single_instance.
 # python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
 #     --dtype bfloat16 --block-size 16 --enable-prefix-caching \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_prefix_run.csv' \
-#     --num-req 10
+#     --num-reqs 10
 
 # NS-3 example
 # Note: NS-3 integration is currently a work in progress. The following command is a placeholder and may not work until the NS-3 integration is complete.
 # python -m serving --cluster-config 'configs/cluster/single_node_single_instance.json' \
 #     --dtype bfloat16 --block-size 16 --network-backend 'ns3' \
 #     --dataset 'workloads/example_trace.jsonl' --output 'outputs/example_ns3_run.csv' \
-#     --num-req 10 
+#     --num-reqs 10 

--- a/workloads/README.md
+++ b/workloads/README.md
@@ -94,6 +94,12 @@ executions.
 | --- | --- | --- | --- | --- | --- |
 | `swe-bench-qwen3-30b-a3b-50-sps0.2.jsonl` | 50 | 765 | 15.3 | 0.2 | Qwen3-30B-A3B |
 
+**There is no SWE-bench generator.** `workloads.generators` has exactly one
+subcommand, `sharegpt`; this file was produced out of band and committed. To
+build your own agentic workload, emit the JSONL directly — the schema is above,
+and the format reference is
+[Workloads → JSONL format](https://llmservingsim.ai/docs/workloads/jsonl-format).
+
 ### Other
 | File | Description |
 | --- | --- |
@@ -131,6 +137,27 @@ python -m workloads.generators sharegpt \
 fill `output_tok_ids` with the model's natural responses (free
 generation). Without it, `output_tok_ids` come straight from the
 ShareGPT assistant turn.
+
+Eight flags gate that mode:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--use-vllm` | off | enable free generation |
+| `--vllm-tp` | `1` | `tensor_parallel_size` for the offline engine |
+| `--vllm-dtype` | `bfloat16` | weight dtype |
+| `--vllm-max-num-seqs` | `1024` | `max_num_seqs`, high on purpose — this is a throughput job |
+| `--vllm-max-num-batched-tokens` | `16384` | `max_num_batched_tokens`, likewise |
+| `--vllm-max-model-len` | model's max | override `max_model_len` |
+| `--vllm-temperature` | `0.0` | `0` = greedy, so generation is reproducible for a seed |
+| `--vllm-repetition-penalty` | `1.1` | `1.0` disables. Above 1.0 keeps free generation from rambling past natural EOS, so output lengths land at typical ShareGPT values (~500-1000 tokens) instead of every request hitting `--max-output-toks` |
+
+These are settings for the generation job, not for the simulated run:
+the generator records only token counts and ids, so a high
+`--vllm-max-num-seqs` here says nothing about what `--max-num-seqs` the
+workload should be simulated at.
+
+Full flag reference:
+[Workloads → ShareGPT generators](https://llmservingsim.ai/docs/workloads/sharegpt-generators).
 
 To create a workload manually, write JSON objects to a `.jsonl` file
 following the format above and pass the file path via `--dataset` to


### PR DESCRIPTION
# Realign the docs with the code

Checked all 56 pages of `docs/` against the implementation. 49 edited, 7 left as
correct. Also updated the in-repo docs that had drifted separately:
`configs/cluster/README.md`, `configs/pim/README.md`, `bench/README.md`,
`profiler/README.md`, `workloads/README.md`, `AGENTS.md`, and three script
comments.

No functional change. The only `.py` diff is a docstring and a `--help` string.

## Incorrect

| Documented | Actual |
| --- | --- |
| Heartbeat log format `step=42 batch=8 prompt_t=1.2k tok/s decode_t=420 tok/s npu_mem=88.4 GB`, in 24 blocks across 15 pages, including every example page's "Expected output" | No such fields. Format is `[1.0s] Avg prompt throughput: … tokens/s, …` plus an indented `├─Running Instance[0]: … reqs, Waiting: …` tree |
| `pim_busy` / `gpu_busy` log fields, on 3 pages | Do not exist. No device utilization counters anywhere in the simulator |
| `workloads/jsonl-format.md` "Validation" section describing a startup pass with line-numbered errors | `load_requests()` has no validation. Missing fields raise `KeyError`, an empty `sub_requests` is silently skipped, a duplicate `session_id` makes completions from either session drive the later one twice |
| All 3 headline rows and 18 per-model cells on `validation.md` | None matched `bench/examples/*/validation/summary.txt`, including sign flips (Llama TPOT `+0.7%` vs `-0.4%`). "Means stay within ~2.5%" was false; worst is `-5.8%` |
| `max_position_embeddings` under "fields the simulator ignores" | Required. Read by direct index in `scheduler.py` and `trace_generator.py`, and silently caps `max_num_batched_tokens` — 4096 on the bundled Phi-mini-MoE |
| PIM bandwidth `device_width × BL × tCK × channel_count`; `[system] channels` called "the most simulator-relevant field" | `bus_width/8 × data_rate/1000`. `channels` is never read; channel count comes from `cpu_mem.mem_size` |
| Trace rows tab-separated, with a gotcha that mixing tabs and spaces "breaks the Chakra parser silently" | `_FMT` writes fixed-width space padding and both readers split on arbitrary whitespace |
| `alpha ∈ [0, 1]`, in 4 places | Not clamped in `fit_alpha.py`, `_skew_alpha`, or the blend. Across the six bundles: p50 0.07–0.13, 14–20% negative, 2–5% above 1 |
| `pim_used`, `last_compute_end_ns`, `last_token_time_ns`, a `prefix_hit_len` CSV column, and completion on `num_computed_tokens` | None exist. Completion is on `num_tokens_reached`, since preemption resets `num_computed_tokens` |
| `bf16-kvfp8` among the bundled variants | Only `bf16` ships. The FP8 example page already said otherwise |
| Adding a PIM `.ini` is a config-only change | `pim_model.py` whitelists the filename stem; a new `.ini` alone raises `ValueError: Unknown PIM spec` |
| "No `--no-verify` to bypass pre-commit hooks" (2 pages); "watch CI on `main`" after merge | No `.pre-commit-config.yaml`, no active hooks. Only workflow is `deploy-docs.yml` |
| Synthetic `meta.yaml` with `skew_fit.per_tp.1.alpha_default: 0.3` | `_skew_alpha` returns 0 unless `skew_fit.enabled` is truthy, so that bundle applies no correction |
| A SWE-bench JSONL generator | `workloads.generators` has one subcommand, `sharegpt` |

## Missing

CLI flag coverage:

| Entry point | Before | After |
| --- | --- | --- |
| `python -m serving` | 29 / 29 | 29 / 29 |
| `python -m profiler` | 11 / 25 | 25 / 25 |
| `python -m bench run` | 9 / 15 | 15 / 15 |
| `python -m bench validate` | 1 / 7 | 7 / 7 |
| `python -m workloads.generators` | 23 / 28 | 28 / 28 |
| **Total** | **73 / 104** | **104 / 104** |

`bench` had no page. `python -m profiler slice` was absent entirely, including
`--tp-refresh` and `--group`.

The 14 per-instance runtime overrides existed only as a table in the reference.
`examples/cluster-config-explained.mdx` listed one optional instance field
(`placement`), so `mem_util`, `reserve_full_isl` and the batching limits were
effectively unreachable, and three appeared on a single page site-wide. Their
semantics were undocumented: `mem_util` is the one nested override and must be a
fraction in `(0, 1]`; `max_num_batched_tokens: 0` resolves to
`max_position_embeddings`, not infinity; `dtype` has a third fallback below the
CLI; sub-batch interleaving is rejected both without attention offloading and
with `pp_size > 1` (the second gate was written down nowhere).

`contributor/conventions.md` gained the scheduler and pipeline invariants that
have caused regressions before: why `is_prefill()` was removed, why sequence
length must not come from `num_computed_tokens`, why the "preserve decode state
on preemption" special case must not return, why pipeline stages may only be cut
on block boundaries (ASTRA-Sim's send/recv tracker keys on `chunk_size`, so a
mismatch deadlocks silently), and why `_axis_bracket` must stay linear.

## Commits

| Commit | Files | Scope |
| --- | --- | --- |
| `467790be` | 7 | Document the CLI surfaces the docs never covered |
| `c641fcfd` | 3 | Make per-instance overrides reachable from the pages people read |
| `d846b636` | 6 | Correct the reference schemas against the code |
| `9a662057` | 32 | Replace the fabricated documentation with the real thing |
| `0d21a01c` | 6 | Correct the install and porting pages, and the copied commands |
| `e7062946` | 7 | Correct the contributor pages |

## Validation

```bash
# onBrokenLinks is 'throw', so this covers links and anchors too.
cd docs && npm run build

# Clean at each of the 6 commits, so the history bisects.
for c in $(git rev-list --reverse main..HEAD); do
    git checkout -q $c && (cd docs && npm run build)
done

git diff main...HEAD -- '*.py'
bash -n serving/run.sh profiler/profile-all.sh bench/bench.sh
```

Also swept: every `--flag` in each `__main__.py` / `register_args` against the
docs (the table above); all 311 backticked `snake_case` identifiers in the docs
against the source (5 were fabricated, the 22 still absent are trace layer
names, ASTRA-Sim C++ terms, pseudocode locals, and keys the docs say do not
exist); all 25 `python -m serving` invocations and 17 JSON blocks in the docs
against the real argparse and cluster-config schema. That last one found
`--num-req` in 3 pages and all 16 `serving/run.sh` scenarios, which only works
via argparse prefix matching and is not a documented spelling — normalized to
`--num-reqs`, behaviour identical.

## Notes

- `docs/docs/reference/bench-cli.md` is the only new page, registered in
  `docs/sidebars.ts`.
- `configs/cluster/rtx4090_single_instance.json` and `profiler/perf/RTX4090/`
  were already untracked and are deliberately not added.
- `CHANGELOG.md` entries naming `profile_fp8.csv` are unchanged; they describe
  what that release did.
- The 7 unedited pages were checked: `simulator/architecture`,
  `simulator/parallelism-mechanics`, `simulator/trace-generation` and
  `profiler/adding-model-architecture` matched the code; the three
  index/overview pages carry no code claims.
