### PR TITLE
Skip already-finished requests in add_done

### DIFF
--- a/serving/core/scheduler.py
+++ b/serving/core/scheduler.py
@@ -358,6 +358,22 @@ class Scheduler:
         self.logger.info("Batch #%d is done", batch.batch_id)
 
         for req in batch.requests:
+            if req.status == RequestStatus.FINISHED:
+                # With pp_size > 1 a request is legitimately in more than one
+                # in-flight batch, so it can finish on an earlier batch while a
+                # later one is still running. vLLM V1 skips exactly this in
+                # ``update_from_output`` -- "the request is already finished.
+                # This can happen if the request is aborted while the model is
+                # executing it (e.g., in pipeline parallelism)" -- and drops that
+                # batch's output whole, tokens included: they are past the
+                # request's target, so nothing wants them.
+                #
+                # Without this the completion path below runs once per in-flight
+                # batch: duplicate rows in the per-request CSV, req_cnt counted
+                # twice, end_time and latency overwritten with the later batch's
+                # clock, and a KeyError in cache_blocks, whose req_to_blocks
+                # entry the first pass already freed.
+                continue
             num_new = batch.scheduled_tokens[req.id]
             # num_computed_tokens was already advanced at schedule time.
             prefill_done_now = req.is_init and req.num_computed_tokens >= req.original_input


### PR DESCRIPTION
Closes #62.

## Cause

With `pp_size > 1` a request is legitimately present in more than one in-flight
batch, so it can finish on an earlier batch while a later one is still running.
`add_done` had no guard for that, so the whole completion path ran once per
in-flight batch.

`_retire()` already sets `req.status = FINISHED`; nothing read it.

## Effects

Prefix caching on — crash. The first pass calls `kv.free()`, which pops
`req_to_blocks[req.id]`; the second reaches `cache_blocks()`, which indexes that
dict directly. `free()` pops with a default and `cache_blocks()` does not, which
is why only the caching path raises, at `scheduler.py:406` rather than `:401`
(on the second pass `num_computed_tokens < num_tokens_reached`, so the
token-produced branch is skipped and the completion branch is not).

Prefix caching off — completes, wrong numbers. `done.append` and
`end_reqs.append` both fire twice, so the request lands in the CSV twice and
`req_cnt` counts it twice. `add_latency()` is also re-run with the later batch's
clock: on the reported case `end_time` went from 2416764003 to 2421020918, so
latency was inflated by 4.26 ms and TPOT with it — in the surviving row as much
as in the duplicate, since both render the same object.

## Why chunked prefill is the trigger

It is the only thing that takes the pipeline to depth 2 with a single request. A
prompt that does not fit the token budget leaves work behind, so the next
`schedule()` forms a second batch while the first is still running; from then on
each completion bumps `num_tokens_reached` by one and the following `schedule()`
consumes it, pinning the depth. Without chunking the first batch takes the whole
prompt, `num_computed_tokens == num_tokens_reached`, `_num_new_tokens` returns 0,
and no second batch is ever formed.

So `completions == min(pp_size, ceil(input_toks / max_num_batched_tokens))`, and
`single_node_pp_instance` (`pp=4`) finishes a 5-chunk prompt four times.

That is also why this never showed up: all three PP scenarios in
`serving/run.sh` use `example_trace.jsonl`, whose requests are 4–22 tokens and
never chunk, so the pipeline never leaves depth 1.

## Fix

Skip requests already marked `FINISHED` at the top of `add_done`'s per-request
loop. Same guard, same placement and same reason as vLLM V1's
`update_from_output`:

```python
if request is None or request.is_finished():
    # The request is already finished. This can happen if the
    # request is aborted while the model is executing it (e.g.,
    # in pipeline parallelism or in async scheduling).
    continue
```

The tokens that batch computed are past the request's target, so nothing wants
them and they are dropped whole — no `gen_t`, no ITL entry, no second
completion. Its simulated cycles still advance the clock, which is faithful: the
work was submitted and ASTRA-Sim ran it, exactly as a real pipeline drains
microbatches already in flight.

## Validation

All three cases from the issue, in the simulator container:

```bash
# was: KeyError: 0 at scheduler.py:406
python3 -m serving --cluster-config configs/cluster/single_node_moe_pp_instance.json \
  --dtype bfloat16 --block-size 16 \
  --dataset workloads/sharegpt-qwen3-30b-a3b-300-sps10.jsonl \
  --num-reqs 1 --max-num-batched-tokens 2048
# -> Total requests: 1, exit 0

# was: Total requests: 2, two CSV rows, end_time 2421020918
... --no-enable-prefix-caching
# -> Total requests: 1, one CSV row, end_time 2416764003

# pp=4 config on a chunked prompt
... --cluster-config configs/cluster/single_node_pp_instance.json \
    --dataset workloads/sharegpt-llama-3.1-8b-300-sps10.jsonl
# -> Total requests: 1, one CSV row
```

Regression: all 14 `serving/run.sh` scenarios, `Total clocks (ns)` **unchanged**
against `main`. The simulator is deterministic, so this is exact equality, and
it confirms the guard does not touch the normal path.

| scenario | clocks | scenario | clocks |
| --- | --- | --- | --- |
| single | 1663996645 | pim | 1643150716 |
| multi | 1664893230 | pim_sub_batch | 2634096516 |
| pd | 1661784496 | pp (`pp=4`) | 1770875992 |
| cxl | 12112686177 | tp_pp | 1469287243 |
| prefix_cpu_mem_pool | 1664893230 | moe_pp | 1801188850 |
| dual_prefix_cpu_mem_pool | 1668890844 | moe | 1945309759 |
| power | 1663996645 | moe_dp_ep | 36551191391 |

The committed `outputs/example_*.csv` are byte-identical after the sweep.

No regression test added — the existing PP scenarios cannot reach this path, and
adding a chunked PP scenario would mean a new committed baseline CSV.

## Adjacent gap, not fixed here

A P/D **prefill** instance retires a request as soon as
`num_computed_tokens >= original_input`. With `pp > 1` and chunked prefill that
condition is met by the *second* batch's scheduling, so the request would be
handed to the decode instance before its tail chunk has actually been computed.
No bundled P/D config sets `pp > 1`, so the path is unexercised; worth a
separate look if P/D ever combines with pipeline parallelism.
