### PR TITLE
Make the simulator ~11x faster with byte-identical results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -677,7 +677,8 @@ No dedicated unit-test suite. Validate by:
 - **Don't commit large files**: generated traces, `.et` files and scratch run
   output are gitignored (`outputs/*` with `!outputs/example_*.csv`,
   `bench/results/`). `astra-sim/inputs/runs/` is cleaned per run unless you
-  pass `--no-cleanup-inputs`, which can leave gigabytes behind
+  pass `--keep-inputs` (or `--save-trace-text`, which implies it), either of
+  which can leave gigabytes behind
 - **Don't use machine-specific absolute paths** in configs or code — use relative paths
   rooted at the repo
 - **Don't add `getattr` fallbacks** for Request attributes — initialize all attributes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,9 @@ are not part of the main branch's tree.
 ```
 profiler/perf/<hw>/<model>/<variant>/tp<N>/*.csv (profiled latencies)
     ↓ _load_perf_db() + _lookup_{dense,per_sequence,attention,moe}()
-trace_generator.py → text trace file
-    ↓ Chakra converter
-graph_generator.py → .et protobuf file
+trace_generator.py → per-layer field tuples (TraceData)
+    ↓ Chakra converter, in-process, via LLMConverter.convert_rows()
+graph_generator.py → .et protobuf file (reused when the rows repeat)
     ↓ stdin/stdout IPC
 ASTRA-Sim (C++) → cycle count
     ↓
@@ -274,9 +274,12 @@ each iteration. Composable helpers:
 - `_emit_final_layers()` — final_layernorm → lm_head → sampler (sampler output goes to REMOTE)
 
 ### Trace file format
-Each trace is a whitespace-aligned text file consumed by the Chakra converter
-(fixed-width columns from `utils.py::_FMT`; the converter splits on any
-whitespace). The sample below is illustrative, not byte-accurate — see
+A trace is a list of per-layer field tuples, handed to the Chakra converter
+in memory. `--save-trace-text` also writes it as a whitespace-aligned text
+file (fixed-width columns from `utils.py::_FMT`), which is the only
+human-readable form of what the simulator emitted — nothing in the pipeline
+reads it. The field spec below describes both representations; the text
+columns are what `indexed_cols()` and `_write_trace()` agree on. The sample below is illustrative, not byte-accurate — see
 `docs/docs/reference/trace-format.md` for the real widths. Every field except the
 last carries an **explicit trailing space** in `_FMT`: `{:<15}` pads a short value
 but emits nothing for one that already fills the column, so a 15-character value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,46 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   `MemoryModel` exists.
 
 ### Changed
+- The simulator is roughly **11x faster** with byte-identical results. Measured
+  on the four `bench/examples/` validation workloads (300 requests each), total
+  wall-clock goes 16m 40s to 1m 26s; the per-example range is 5.2x
+  (RTXPRO6000/Qwen3-32B, whose cost is dominated by ASTRA-Sim's own graph
+  simulation) to 24.6x (RTX4090/Llama-3.1-8B). The 19 `serving/run.sh`
+  scenarios go 18.95 min to 1.94 min. Every one of those scenarios produces an
+  unchanged `Total clocks (ns)`, and all four `bench/examples` `sim.csv` files
+  are byte-identical, so validation accuracy against vLLM is unchanged to the
+  bit. The work was:
+  - The Chakra converter runs **in-process** instead of as a fresh
+    `python -m chakra...` subprocess per batch. The subprocess cost ~56 ms per
+    call, of which ~52 ms was interpreter startup plus the protobuf import
+    against ~1.3 ms of conversion, which made graph generation 73-85% of
+    wall-clock on every config profiled.
+  - The converter takes the trace **as field tuples**, not as text. Formatting
+    rows into padded columns, writing the file, reading it back and splitting
+    each line again is pure overhead once both sides are in the same process.
+    The text file is now written only when `--no-cleanup-inputs` asks for it.
+  - **Converted graphs are reused** when a batch produces an identical trace.
+    A DP group with uneven load spends half its waves on dummy batches whose
+    trace is nearly a constant: on the swe-bench MoE DP+EP example, 4,405 of
+    8,810 batches, and only 22 of those 4,405 traces are distinct.
+  - **ASTRA-Sim stops re-asking an idle NPU** until its answer could change --
+    another NPU reporting a new iteration, a workload being assigned, or
+    simulated time reaching a known request arrival. 336,894 of 337,786
+    answers on a 10-request 8-NPU run were `pass`, and 336,890 of those were
+    sent while another instance was mid-batch. Handshakes on that config drop
+    337,786 to 2,462.
+  - The analytical frontends no longer print a per-tick `Checking NPU ...`
+    line per NPU. The frontend had to read every one off the pipe before
+    reaching the `Waiting` it was blocked on: 78% of the lines read on a
+    10-request 8-NPU run, 99.6% on an MoE DP+EP run.
+  - Profile tables are built in plain Python and only for the TP degrees a run
+    touches, taking startup for a TP=1 run from 1435 ms to 50 ms; the model
+    architecture config is cached instead of re-parsed per scheduled batch.
+- Graph metadata stores the trace's **path** rather than its entire text.
+  Nothing consumed it -- `ETFeeder::readGlobalMetadata()` reads the message and
+  discards it -- and it was 70% of every `.et`. Files shrink from 117,112 to
+  24,403 bytes on the swe-bench MoE DP+EP example, about 720 MB to 180 MB of
+  I/O per run. Wall-clock is unaffected; this is an I/O and disk-space change.
 - All four canonical examples were regenerated on current `main`, and the
   committed validation numbers moved: the previous summaries predated the block
   pool rework, the pipeline-stage fix and the attention-interpolation change,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   - The converter takes the trace **as field tuples**, not as text. Formatting
     rows into padded columns, writing the file, reading it back and splitting
     each line again is pure overhead once both sides are in the same process.
-    The text file is now written only when `--no-cleanup-inputs` asks for it.
+    The text file is now written only when `--save-trace-text` asks for it.
   - **Converted graphs are reused** when a batch produces an identical trace.
     A DP group with uneven load spends half its waves on dummy batches whose
     trace is nearly a constant: on the swe-bench MoE DP+EP example, 4,405 of
@@ -413,7 +413,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 - `outputs/*` (except the committed `outputs/example_*.csv`) and
   `astra-sim/inputs/runs/` are now gitignored. `AGENTS.md` claimed output CSVs
   and generated traces already were; they were not, so scratch from every run
-  accumulated in `git status`, and `--no-cleanup-inputs` could leave gigabytes
+  accumulated in `git status`, and keeping the inputs could leave gigabytes
   of ASTRA-Sim inputs behind.
 - Documentation corrections: the attention lookup was described as
   "nearest-neighbour on `(prefill_chunk, n_decode)`" when it has always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   - Profile tables are built in plain Python and only for the TP degrees a run
     touches, taking startup for a TP=1 run from 1435 ms to 50 ms; the model
     architecture config is cached instead of re-parsed per scheduled batch.
+- **`--cleanup-inputs` is replaced by two flags**, `--save-trace-text` and
+  `--keep-inputs`, both defaulting off — the same observable default as
+  `--cleanup-inputs` defaulting on, without the double negative. It was doing two
+  unrelated jobs, which were only the same switch because the trace text used to
+  be written unconditionally and then deleted: `--save-trace-text` writes each
+  batch's trace as text for inspection (nothing in the pipeline reads it, so it
+  is produced only on request) and implies `--keep-inputs`, while `--keep-inputs`
+  alone preserves the `.et` workloads and the generated network / system / memory
+  configs so a run can be replayed through ASTRA-Sim by hand. Scripts passing
+  `--no-cleanup-inputs` need to pass `--save-trace-text` or `--keep-inputs`
+  instead.
 - Graph metadata stores the trace's **path** rather than its entire text.
   Nothing consumed it -- `ETFeeder::readGlobalMetadata()` reads the message and
   discards it -- and it was 70% of every `.et`. Files shrink from 117,112 to

--- a/docs/docs/examples/cluster-config-explained.mdx
+++ b/docs/docs/examples/cluster-config-explained.mdx
@@ -281,7 +281,7 @@ object does nothing at all: no key reads it, and no error is raised.
 | Router, cross-instance by definition | `--request-routing-policy`, `--expert-routing-policy` |
 | Shared lower KV tier | `--enable-prefix-sharing`, `--prefix-storage` |
 | Workload, one per run | `--dataset`, `--num-reqs`, `--skip-prefill` |
-| Run plumbing | `--output`, `--run-id`, `--inputs-root`, `--cleanup-inputs`, `--log-interval`, `--log-level` |
+| Run plumbing | `--output`, `--run-id`, `--inputs-root`, `--save-trace-text`, `--keep-inputs`, `--log-interval`, `--log-level` |
 
 ### Two rejected combinations
 

--- a/docs/docs/examples/disaggregated/pim-attention-offload.mdx
+++ b/docs/docs/examples/disaggregated/pim-attention-offload.mdx
@@ -101,7 +101,7 @@ attention kernel from the NPU profile to the PIM profile. The rest
 throughput and TPOT, not as a utilization counter. To see whether PIM
 is the bottleneck, compare TPOT against the same workload without
 `--enable-attn-offloading`, or inspect a trace with
-`--no-cleanup-inputs` and look at the `PIM` marker blocks.
+`--save-trace-text` and look at the `PIM` marker blocks.
 
 ## What's interesting
 

--- a/docs/docs/reference/cli-flags.md
+++ b/docs/docs/reference/cli-flags.md
@@ -87,7 +87,8 @@ removed after a successful simulation by default.
 | --- | --- | --- | --- |
 | `--run-id` | string | auto-generated | Path-safe id for this simulation run. Used in `astra-sim/inputs/runs/<run-id>` and the `{run_id}` output placeholder |
 | `--inputs-root` | path | `astra-sim/inputs/runs/<run-id>` | Override the generated ASTRA-Sim input root, for example to place intermediates on local SSD or tmpfs |
-| `--cleanup-inputs` / `--no-cleanup-inputs` | bool | `true` | Remove generated trace files after Chakra conversion and remove the generated run directory after a successful simulation. Use `--no-cleanup-inputs` to preserve traces, Chakra workloads, and input configs for debugging |
+| `--save-trace-text` / `--no-save-trace-text` | bool | `false` | Write each batch's trace as text, for inspection. Nothing in the pipeline reads it — the Chakra converter takes the trace rows directly — so it is produced only on request, and it is the only human-readable form of what the simulator emitted. Implies `--keep-inputs` |
+| `--keep-inputs` / `--no-keep-inputs` | bool | `false` | Keep the generated ASTRA-Sim inputs under `astra-sim/inputs/runs/<run-id>` after a successful simulation: the Chakra `.et` workloads and the generated network / system / memory configs, so a run can be replayed through ASTRA-Sim by hand |
 
 ## Logging
 

--- a/docs/docs/reference/cluster-config.md
+++ b/docs/docs/reference/cluster-config.md
@@ -318,7 +318,7 @@ instance object is silently ignored — nothing reads the key:
 | Router (cross-instance by definition) | `--request-routing-policy`, `--expert-routing-policy` |
 | Shared lower KV tier | `--enable-prefix-sharing`, `--prefix-storage` |
 | Workload (one per run) | `--dataset`, `--num-reqs`, `--skip-prefill` |
-| Run plumbing | `--output`, `--run-id`, `--inputs-root`, `--cleanup-inputs`, `--log-interval`, `--log-level` |
+| Run plumbing | `--output`, `--run-id`, `--inputs-root`, `--save-trace-text`, `--keep-inputs`, `--log-interval`, `--log-level` |
 
 #### Worked example
 

--- a/docs/docs/reference/trace-format.md
+++ b/docs/docs/reference/trace-format.md
@@ -5,10 +5,17 @@ title: Trace file format
 
 # Trace file format
 
-The simulator's `trace_generator.py` writes a per-batch text trace
-that the Chakra converter then reads to produce the `.et` file
-ASTRA-Sim consumes. This page is the **field-by-field spec** of that
-text trace.
+The simulator's `trace_generator.py` builds a per-batch trace that the
+Chakra converter turns into the `.et` file ASTRA-Sim consumes. This page
+is the **field-by-field spec** of that trace.
+
+The trace is normally handed to the converter **in memory**, as one field
+tuple per layer, and never becomes text: the converter runs inside the
+simulator process, so formatting the fields into padded columns only to
+split them apart again was pure overhead. The text form below is still
+exactly what the fields mean, and it is still what gets written when you
+ask for it with `--no-cleanup-inputs` — so it remains the format to read
+when inspecting what the simulator emitted.
 
 For the *internals* of how this trace is produced, see
 **[Simulator → Trace generation](/docs/simulator/trace-generation)**.
@@ -20,8 +27,13 @@ astra-sim/inputs/runs/<run_id>/trace/<hardware>/<model>/instance_<i>_batch_<b>.t
 ```
 
 One file per (instance × batch), under the run-specific ASTRA-Sim input
-root. Regenerated every iteration and removed after Chakra conversion by
-default. Use `--no-cleanup-inputs` to preserve generated traces.
+root — written only when `--no-cleanup-inputs` is passed. By default no
+text file is produced for a batch at all; the rows go straight to the
+converter.
+
+The one trace that is always written as text is the event handler's
+(`event_handler.txt`), because `generate_event` writes it to disk
+directly rather than building rows.
 
 ## File structure
 

--- a/docs/docs/reference/trace-format.md
+++ b/docs/docs/reference/trace-format.md
@@ -14,7 +14,7 @@ tuple per layer, and never becomes text: the converter runs inside the
 simulator process, so formatting the fields into padded columns only to
 split them apart again was pure overhead. The text form below is still
 exactly what the fields mean, and it is still what gets written when you
-ask for it with `--no-cleanup-inputs` — so it remains the format to read
+ask for it with `--save-trace-text` — so it remains the format to read
 when inspecting what the simulator emitted.
 
 For the *internals* of how this trace is produced, see
@@ -27,13 +27,11 @@ astra-sim/inputs/runs/<run_id>/trace/<hardware>/<model>/instance_<i>_batch_<b>.t
 ```
 
 One file per (instance × batch), under the run-specific ASTRA-Sim input
-root — written only when `--no-cleanup-inputs` is passed. By default no
-text file is produced for a batch at all; the rows go straight to the
-converter.
+root — written only when `--save-trace-text` is passed. By default no
+text file is produced at all; the rows go straight to the converter.
 
-The one trace that is always written as text is the event handler's
-(`event_handler.txt`), because `generate_event` writes it to disk
-directly rather than building rows.
+That includes the event handler's trace (`event_handler.txt`), which is
+built from rows like any other.
 
 ## File structure
 

--- a/docs/docs/simulator/architecture.mdx
+++ b/docs/docs/simulator/architecture.mdx
@@ -163,11 +163,14 @@ Concretely:
 
 1. The Python scheduler decides which requests run this iteration and
    produces a `Batch`.
-2. `trace_generator` writes a per-layer text trace to
-   `astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
-3. `graph_generator` shells out to the Chakra converter, producing a
-   protobuf graph at
+2. `trace_generator` builds a per-layer trace as field tuples. With
+   `--save-trace-text` it is also written to
+   `astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`
+   for inspection; nothing in the pipeline reads that file.
+3. `graph_generator` hands those rows to the Chakra converter, running
+   in-process, producing a protobuf graph at
    `astra-sim/inputs/runs/<run_id>/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
+   A trace identical to one already converted reuses its graph.
 4. `controller.write_flush(process, "<workload-path>")` sends that
    path over stdin.
 5. ASTRA-Sim reads the `.et` file, executes the compute + comm graph,
@@ -175,12 +178,26 @@ Concretely:
 6. `controller.read_wait` parses that line; the main loop hands the
    cycle count to `scheduler.add_done` to update request metrics.
 
-The protocol is just three commands on the Python → C++ direction:
+The protocol is a handful of commands on the Python → C++ direction:
 
 - A workload path, start running this batch.
-- `pass`: re-poll without computing (used during DP-group sync waits).
+- `pass`: nothing to run. ASTRA-Sim stops re-asking this NPU until
+  something could change the answer — some NPU reporting an iteration
+  the frontend has not processed, or a workload being assigned.
+- `pass <tick>`: the same, plus the next known request arrival. That is
+  the one thing the backend cannot work out for itself, and without it
+  an idle instance would stay quiet past an arrival it should have
+  admitted while every other instance was mid-batch.
+- `pass -1`: this `pass` *changed* scheduler state, so it is not
+  idempotent — the three DP-barrier passes do that (joining a round with
+  a dummy batch, joining it with a real batch, handing a batch claim
+  back). Treated exactly like a workload assignment: re-open every NPU.
 - `done`: this instance is idle.
 - `exit`: shut down.
+
+The frontend and the binary have to match, since an older binary compares
+the answer to `"pass"` exactly and would read `pass 12345` as a workload
+path. Rebuild after changing either side.
 
 There is no shared memory, no callback API, no FFI, only files and a
 text protocol. Adding a new feature on the Python side rarely

--- a/docs/docs/simulator/reading-output.md
+++ b/docs/docs/simulator/reading-output.md
@@ -140,7 +140,7 @@ all of it; every sample on this page is copied from there.
 
 The **Run ID** and inputs root are what you need to find a run's
 intermediate ASTRA-Sim files, and they only survive if you passed
-`--no-cleanup-inputs`.
+`--keep-inputs` (or `--save-trace-text`, which implies it).
 
 The **KV Cache Initialization** line is the one to read first when
 comparing against real vLLM: it reports the capacity the simulator

--- a/docs/docs/simulator/request-lifecycle.md
+++ b/docs/docs/simulator/request-lifecycle.md
@@ -160,21 +160,22 @@ profile DB:
 - MoE → 2D over `(local_tokens, activated_experts)`, profiled at
   TP=1.
 
-The output is a tab-separated text trace at
-`astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`.
-The text trace is an intermediate input to the Chakra converter and is
-removed after the `.et` graph is generated unless `--no-cleanup-inputs`
-is set.
+The output is a list of per-layer field tuples, handed straight to the
+Chakra converter. Pass `--save-trace-text` to also write it as a
+tab-separated text trace at
+`astra-sim/inputs/runs/<run_id>/trace/<hw>/<model>/instance_{i}_batch_{b}.txt`
+-- nothing in the pipeline reads that file, but it is the only
+human-readable form of what the simulator emitted.
 Full mechanics on **[Trace generation](./trace-generation)**.
 
 ## Stage 7, Converted to Chakra graph
 
-`graph_generator.generate_graph` shells out to Chakra's text→protobuf
-converter, producing
+`graph_generator.generate_graph` calls Chakra's converter in-process,
+handing it the trace rows, producing
 `astra-sim/inputs/runs/<run_id>/workload/<hw>/<model>/instance_{i}_batch_{b}/llm.et`.
-Chakra workloads remain available while ASTRA-Sim consumes them; the
-run directory is removed after a successful simulation unless
-`--no-cleanup-inputs` is set.
+An identical trace reuses the graph it already converted. Chakra workloads
+remain available while ASTRA-Sim consumes them; the run directory is removed
+after a successful simulation unless `--keep-inputs` is set.
 
 The Chakra converter creates:
 

--- a/docs/docs/simulator/specialized/pim-offload.md
+++ b/docs/docs/simulator/specialized/pim-offload.md
@@ -161,7 +161,7 @@ a slowdown to PIM:
 
 - Run the same workload with and without `--enable-attn-offloading` and
   compare TPOT.
-- Pass `--no-cleanup-inputs` and read the emitted trace: PIM work sits
+- Pass `--save-trace-text` and read the emitted trace: PIM work sits
   between `PIM <channel>` and `PIM END` markers, with its own
   `comp_time`.
 - Widen the node's `cpu_mem.mem_size` to buy more PIM channels — channel

--- a/docs/docs/simulator/trace-generation.md
+++ b/docs/docs/simulator/trace-generation.md
@@ -40,7 +40,9 @@ flowchart LR
     PERSEQ --> EMIT
     SKEWBLEND --> EMIT
     MOE --> EMIT
-    EMIT --> TRACEFILE["trace .txt<br/>(per layer)"]
+    EMIT --> ROWS["TraceData<br/>(field tuple per layer)"]
+    ROWS --> GRAPH["Chakra converter<br/>(in-process)"]
+    ROWS -.->|--save-trace-text| TRACEFILE["trace .txt<br/>(for inspection)"]
 ```
 
 ## The data the simulator consumes

--- a/docs/src/pages/changelog.md
+++ b/docs/src/pages/changelog.md
@@ -112,7 +112,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   - The converter takes the trace **as field tuples**, not as text. Formatting
     rows into padded columns, writing the file, reading it back and splitting
     each line again is pure overhead once both sides are in the same process.
-    The text file is now written only when `--no-cleanup-inputs` asks for it.
+    The text file is now written only when `--save-trace-text` asks for it.
   - **Converted graphs are reused** when a batch produces an identical trace.
     A DP group with uneven load spends half its waves on dummy batches whose
     trace is nearly a constant: on the swe-bench MoE DP+EP example, 4,405 of
@@ -416,7 +416,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 - `outputs/*` (except the committed `outputs/example_*.csv`) and
   `astra-sim/inputs/runs/` are now gitignored. `AGENTS.md` claimed output CSVs
   and generated traces already were; they were not, so scratch from every run
-  accumulated in `git status`, and `--no-cleanup-inputs` could leave gigabytes
+  accumulated in `git status`, and keeping the inputs could leave gigabytes
   of ASTRA-Sim inputs behind.
 - Documentation corrections: the attention lookup was described as
   "nearest-neighbour on `(prefill_chunk, n_decode)`" when it has always

--- a/docs/src/pages/changelog.md
+++ b/docs/src/pages/changelog.md
@@ -95,6 +95,46 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   `MemoryModel` exists.
 
 ### Changed
+- The simulator is roughly **11x faster** with byte-identical results. Measured
+  on the four `bench/examples/` validation workloads (300 requests each), total
+  wall-clock goes 16m 40s to 1m 26s; the per-example range is 5.2x
+  (RTXPRO6000/Qwen3-32B, whose cost is dominated by ASTRA-Sim's own graph
+  simulation) to 24.6x (RTX4090/Llama-3.1-8B). The 19 `serving/run.sh`
+  scenarios go 18.95 min to 1.94 min. Every one of those scenarios produces an
+  unchanged `Total clocks (ns)`, and all four `bench/examples` `sim.csv` files
+  are byte-identical, so validation accuracy against vLLM is unchanged to the
+  bit. The work was:
+  - The Chakra converter runs **in-process** instead of as a fresh
+    `python -m chakra...` subprocess per batch. The subprocess cost ~56 ms per
+    call, of which ~52 ms was interpreter startup plus the protobuf import
+    against ~1.3 ms of conversion, which made graph generation 73-85% of
+    wall-clock on every config profiled.
+  - The converter takes the trace **as field tuples**, not as text. Formatting
+    rows into padded columns, writing the file, reading it back and splitting
+    each line again is pure overhead once both sides are in the same process.
+    The text file is now written only when `--no-cleanup-inputs` asks for it.
+  - **Converted graphs are reused** when a batch produces an identical trace.
+    A DP group with uneven load spends half its waves on dummy batches whose
+    trace is nearly a constant: on the swe-bench MoE DP+EP example, 4,405 of
+    8,810 batches, and only 22 of those 4,405 traces are distinct.
+  - **ASTRA-Sim stops re-asking an idle NPU** until its answer could change --
+    another NPU reporting a new iteration, a workload being assigned, or
+    simulated time reaching a known request arrival. 336,894 of 337,786
+    answers on a 10-request 8-NPU run were `pass`, and 336,890 of those were
+    sent while another instance was mid-batch. Handshakes on that config drop
+    337,786 to 2,462.
+  - The analytical frontends no longer print a per-tick `Checking NPU ...`
+    line per NPU. The frontend had to read every one off the pipe before
+    reaching the `Waiting` it was blocked on: 78% of the lines read on a
+    10-request 8-NPU run, 99.6% on an MoE DP+EP run.
+  - Profile tables are built in plain Python and only for the TP degrees a run
+    touches, taking startup for a TP=1 run from 1435 ms to 50 ms; the model
+    architecture config is cached instead of re-parsed per scheduled batch.
+- Graph metadata stores the trace's **path** rather than its entire text.
+  Nothing consumed it -- `ETFeeder::readGlobalMetadata()` reads the message and
+  discards it -- and it was 70% of every `.et`. Files shrink from 117,112 to
+  24,403 bytes on the swe-bench MoE DP+EP example, about 720 MB to 180 MB of
+  I/O per run. Wall-clock is unaffected; this is an I/O and disk-space change.
 - All four canonical examples were regenerated on current `main`, and the
   committed validation numbers moved: the previous summaries predated the block
   pool rework, the pipeline-stage fix and the attention-interpolation change,

--- a/docs/src/pages/changelog.md
+++ b/docs/src/pages/changelog.md
@@ -130,6 +130,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   - Profile tables are built in plain Python and only for the TP degrees a run
     touches, taking startup for a TP=1 run from 1435 ms to 50 ms; the model
     architecture config is cached instead of re-parsed per scheduled batch.
+- **`--cleanup-inputs` is replaced by two flags**, `--save-trace-text` and
+  `--keep-inputs`, both defaulting off — the same observable default as
+  `--cleanup-inputs` defaulting on, without the double negative. It was doing two
+  unrelated jobs, which were only the same switch because the trace text used to
+  be written unconditionally and then deleted: `--save-trace-text` writes each
+  batch's trace as text for inspection (nothing in the pipeline reads it, so it
+  is produced only on request) and implies `--keep-inputs`, while `--keep-inputs`
+  alone preserves the `.et` workloads and the generated network / system / memory
+  configs so a run can be replayed through ASTRA-Sim by hand. Scripts passing
+  `--no-cleanup-inputs` need to pass `--save-trace-text` or `--keep-inputs`
+  instead.
 - Graph metadata stores the trace's **path** rather than its entire text.
   Nothing consumed it -- `ETFeeder::readGlobalMetadata()` reads the message and
   discards it -- and it was 70% of every `.et`. Files shrink from 117,112 to

--- a/serving/README.md
+++ b/serving/README.md
@@ -183,10 +183,11 @@ matching `sequence:` rather than editing this file.
 Parses the user-provided cluster config JSON from `configs/cluster/` and generates the
 ASTRA-Sim input files under `astra-sim/inputs/runs/<run_id>/`: `network/network.yml`,
 `memory/memory_expansion.json`, and `system/system.json`.
-Per-iteration text traces are removed after Chakra conversion by default, and the
-generated run directory is removed after a successful simulation by default. Use
-`--no-cleanup-inputs` to preserve traces, Chakra workloads, and input configs for
-debugging.
+Per-iteration text traces are not produced at all by default -- the Chakra
+converter takes the trace rows straight from the trace generator -- and the
+generated run directory is removed after a successful simulation. Use
+`--save-trace-text` to write the text for inspection (it implies `--keep-inputs`),
+or `--keep-inputs` alone to preserve the Chakra workloads and input configs.
 For DP groups, generates a multi-dimensional network topology, innermost dimension
 first: `[tp_size, dp_group_size]`, or `[tp_size, pp_size, dp_group_size]` when
 `pp_size > 1`, matching vLLM's `all_ranks.reshape(-1, dp, pp, pcp, tp)`. The

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -319,6 +319,12 @@ def main():
                         help='remove generated ASTRA-Sim inputs under astra-sim/inputs/runs/<run-id> '
                         'after a successful simulation (default: enabled). Use --no-cleanup-inputs '
                         'to preserve generated trace files, Chakra workloads, and input configs for debugging')
+    parser.add_argument('--chakra-in-process', action=argparse.BooleanOptionalAction, default=True,
+                        help='run the Chakra trace-to-protobuf converter inside the simulator process '
+                        '(default: enabled). Spawning it as a subprocess costs ~56 ms of interpreter '
+                        'startup per batch against ~1.3 ms of conversion work. Use '
+                        '--no-chakra-in-process to fall back to the subprocess, which isolates '
+                        'converter crashes at the cost of dominating wall-clock')
     parser.add_argument('--skip-prefill', action='store_true', default=False,
                         help='skip the prefill phase, running decode only')
     parser.add_argument('--num-reqs', type=int, default=0,
@@ -580,7 +586,7 @@ def main():
     generate_event(int(event_time), inputs_root=run_paths.inputs_root)
     # Make Chakra Grapth
     generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root,
-                   cleanup_trace=args.cleanup_inputs)
+                   cleanup_trace=args.cleanup_inputs, in_process=args.chakra_in_process)
     # set first workload file
     workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
@@ -756,7 +762,8 @@ def main():
                                        inst_cfg["enable_local_offloading"],
                                        workload_name=dp_workload_name,
                                        inputs_root=run_paths.inputs_root,
-                                       cleanup_trace=args.cleanup_inputs)
+                                       cleanup_trace=args.cleanup_inputs,
+                                       in_process=args.chakra_in_process)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                     workload_name=dp_workload_name,
@@ -832,7 +839,8 @@ def main():
                                            inst_cfg["enable_local_offloading"],
                                            workload_name=dp_workload_name,
                                            inputs_root=run_paths.inputs_root,
-                                           cleanup_trace=args.cleanup_inputs)
+                                           cleanup_trace=args.cleanup_inputs,
+                                           in_process=args.chakra_in_process)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                         workload_name=dp_workload_name,
@@ -867,7 +875,8 @@ def main():
                                    instance_id, inst2npu_mapping[instance_id],
                                    inst_cfg["enable_local_offloading"],
                                    inputs_root=run_paths.inputs_root,
-                                   cleanup_trace=args.cleanup_inputs)
+                                   cleanup_trace=args.cleanup_inputs,
+                                   in_process=args.chakra_in_process)
                     workload = get_workload(new_req, instance["hardware"], instance_id,
                                             inputs_root=run_paths.inputs_root)
                     controller.write_flush(p, workload)

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -778,7 +778,7 @@ def main():
                         batch.workload_name = dp_workload_name
                         inst = instances[inst_id]
                         inst_cfg = instance_runtime_configs[inst_id]
-                        generate_trace(batch, inst["hardware"], inst["tp_size"], inst["pp_size"],
+                        trace_data = generate_trace(batch, inst["hardware"], inst["tp_size"], inst["pp_size"],
                                        inst["local_ep"], inst["ep_total"], inst["pd_type"],
                                        nid, inst_id,
                                        inst_cfg["max_num_batched_tokens"], inst_cfg["max_num_seqs"],
@@ -799,7 +799,8 @@ def main():
                                        inputs_root=run_paths.inputs_root,
                                        cleanup_trace=args.cleanup_inputs,
                                        in_process=args.chakra_in_process,
-                                       reuse_graphs=args.reuse_graphs)
+                                       reuse_graphs=args.reuse_graphs,
+                                       trace=trace_data)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                     workload_name=dp_workload_name,
@@ -857,7 +858,7 @@ def main():
                             batch.workload_name = dp_workload_name
                             inst = instances[inst_id]
                             inst_cfg = instance_runtime_configs[inst_id]
-                            generate_trace(batch, inst["hardware"], inst["tp_size"], inst["pp_size"],
+                            trace_data = generate_trace(batch, inst["hardware"], inst["tp_size"], inst["pp_size"],
                                            inst["local_ep"], inst["ep_total"], inst["pd_type"],
                                            nid, inst_id,
                                            inst_cfg["max_num_batched_tokens"], inst_cfg["max_num_seqs"],
@@ -878,7 +879,8 @@ def main():
                                            inputs_root=run_paths.inputs_root,
                                            cleanup_trace=args.cleanup_inputs,
                                            in_process=args.chakra_in_process,
-                                           reuse_graphs=args.reuse_graphs)
+                                           reuse_graphs=args.reuse_graphs,
+                                           trace=trace_data)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                         workload_name=dp_workload_name,
@@ -896,7 +898,7 @@ def main():
                 else:
                     # Independent instance: generate trace immediately
                     inst_cfg = instance_runtime_configs[instance_id]
-                    generate_trace(new_req, instance["hardware"], instance["tp_size"], instance["pp_size"],
+                    trace_data = generate_trace(new_req, instance["hardware"], instance["tp_size"], instance["pp_size"],
                                    instance["local_ep"], instance["ep_total"],
                                    instance["pd_type"],
                                    node_id, instance_id,
@@ -915,7 +917,8 @@ def main():
                                    inputs_root=run_paths.inputs_root,
                                    cleanup_trace=args.cleanup_inputs,
                                    in_process=args.chakra_in_process,
-                                   reuse_graphs=args.reuse_graphs)
+                                   reuse_graphs=args.reuse_graphs,
+                                   trace=trace_data)
                     workload = get_workload(new_req, instance["hardware"], instance_id,
                                             inputs_root=run_paths.inputs_root)
                     controller.write_flush(p, workload)

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -346,19 +346,6 @@ def main():
                         help='remove generated ASTRA-Sim inputs under astra-sim/inputs/runs/<run-id> '
                         'after a successful simulation (default: enabled). Use --no-cleanup-inputs '
                         'to preserve generated trace files, Chakra workloads, and input configs for debugging')
-    parser.add_argument('--chakra-in-process', action=argparse.BooleanOptionalAction, default=True,
-                        help='run the Chakra trace-to-protobuf converter inside the simulator process '
-                        '(default: enabled). Spawning it as a subprocess costs ~56 ms of interpreter '
-                        'startup per batch against ~1.3 ms of conversion work. Use '
-                        '--no-chakra-in-process to fall back to the subprocess, which isolates '
-                        'converter crashes at the cost of dominating wall-clock')
-    parser.add_argument('--reuse-graphs', action=argparse.BooleanOptionalAction, default=True,
-                        help='reuse an already-converted Chakra graph when a batch produces a '
-                        'byte-identical trace (default: enabled). A DP group with uneven load '
-                        'spends half its waves on dummy batches whose trace is very nearly a '
-                        'constant, so the same graph is otherwise converted thousands of times. '
-                        'The cache is keyed on the trace bytes and the converter\'s other '
-                        'inputs, so a hit is byte-identical to a conversion')
     parser.add_argument('--skip-prefill', action='store_true', default=False,
                         help='skip the prefill phase, running decode only')
     parser.add_argument('--num-reqs', type=int, default=0,
@@ -620,8 +607,7 @@ def main():
     generate_event(int(event_time), inputs_root=run_paths.inputs_root)
     # Make Chakra Grapth
     generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root,
-                   cleanup_trace=args.cleanup_inputs, in_process=args.chakra_in_process,
-                   reuse_graphs=args.reuse_graphs)
+                   cleanup_trace=args.cleanup_inputs)
     # set first workload file
     workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
@@ -798,8 +784,6 @@ def main():
                                        workload_name=dp_workload_name,
                                        inputs_root=run_paths.inputs_root,
                                        cleanup_trace=args.cleanup_inputs,
-                                       in_process=args.chakra_in_process,
-                                       reuse_graphs=args.reuse_graphs,
                                        trace=trace_data)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
@@ -878,8 +862,6 @@ def main():
                                            workload_name=dp_workload_name,
                                            inputs_root=run_paths.inputs_root,
                                            cleanup_trace=args.cleanup_inputs,
-                                           in_process=args.chakra_in_process,
-                                           reuse_graphs=args.reuse_graphs,
                                            trace=trace_data)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
@@ -916,8 +898,6 @@ def main():
                                    inst_cfg["enable_local_offloading"],
                                    inputs_root=run_paths.inputs_root,
                                    cleanup_trace=args.cleanup_inputs,
-                                   in_process=args.chakra_in_process,
-                                   reuse_graphs=args.reuse_graphs,
                                    trace=trace_data)
                     workload = get_workload(new_req, instance["hardware"], instance_id,
                                             inputs_root=run_paths.inputs_root)

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -354,6 +354,13 @@ def main():
                         'startup per batch against ~1.3 ms of conversion work. Use '
                         '--no-chakra-in-process to fall back to the subprocess, which isolates '
                         'converter crashes at the cost of dominating wall-clock')
+    parser.add_argument('--reuse-graphs', action=argparse.BooleanOptionalAction, default=True,
+                        help='reuse an already-converted Chakra graph when a batch produces a '
+                        'byte-identical trace (default: enabled). A DP group with uneven load '
+                        'spends half its waves on dummy batches whose trace is very nearly a '
+                        'constant, so the same graph is otherwise converted thousands of times. '
+                        'The cache is keyed on the trace bytes and the converter\'s other '
+                        'inputs, so a hit is byte-identical to a conversion')
     parser.add_argument('--skip-prefill', action='store_true', default=False,
                         help='skip the prefill phase, running decode only')
     parser.add_argument('--num-reqs', type=int, default=0,
@@ -615,7 +622,8 @@ def main():
     generate_event(int(event_time), inputs_root=run_paths.inputs_root)
     # Make Chakra Grapth
     generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root,
-                   cleanup_trace=args.cleanup_inputs, in_process=args.chakra_in_process)
+                   cleanup_trace=args.cleanup_inputs, in_process=args.chakra_in_process,
+                   reuse_graphs=args.reuse_graphs)
     # set first workload file
     workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
@@ -792,7 +800,8 @@ def main():
                                        workload_name=dp_workload_name,
                                        inputs_root=run_paths.inputs_root,
                                        cleanup_trace=args.cleanup_inputs,
-                                       in_process=args.chakra_in_process)
+                                       in_process=args.chakra_in_process,
+                                       reuse_graphs=args.reuse_graphs)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                     workload_name=dp_workload_name,
@@ -869,7 +878,8 @@ def main():
                                            workload_name=dp_workload_name,
                                            inputs_root=run_paths.inputs_root,
                                            cleanup_trace=args.cleanup_inputs,
-                                           in_process=args.chakra_in_process)
+                                           in_process=args.chakra_in_process,
+                                           reuse_graphs=args.reuse_graphs)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
                                                                         workload_name=dp_workload_name,
@@ -905,7 +915,8 @@ def main():
                                    inst_cfg["enable_local_offloading"],
                                    inputs_root=run_paths.inputs_root,
                                    cleanup_trace=args.cleanup_inputs,
-                                   in_process=args.chakra_in_process)
+                                   in_process=args.chakra_in_process,
+                                   reuse_graphs=args.reuse_graphs)
                     workload = get_workload(new_req, instance["hardware"], instance_id,
                                             inputs_root=run_paths.inputs_root)
                     controller.write_flush(p, workload)

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -62,7 +62,7 @@ def _pad_batch_to_max(batch, max_len):
     batch.num_decode += pad              # counted for lm_head / dense shape
 
 
-def _pass_response(router, current, suppressible=True):
+def _pass_response(router, current, state_changed=False):
     """The "pass" answer, carrying the next known arrival when there is one.
 
     ASTRA-Sim stops re-asking an NPU that passed until either some NPU
@@ -73,17 +73,15 @@ def _pass_response(router, current, suppressible=True):
     past an arrival it should have admitted, in the case where every other
     instance is still mid-batch and so no report is coming.
 
-    ``suppressible=False`` sends ``pass -1``, which opts the NPU out. That
-    is required for DP-group instances, where being polled is itself part
-    of the model: an idle member emits a 1-token dummy batch so the round's
-    ALLTOALL still syncs, so the poll rate decides how many dummy waves
-    exist. Suppressing them moved moe_dp_pp by -4.0% (578 batches -> 572)
-    and moe_dp_tp_pp by +0.14%. That poll-rate dependence is a pre-existing
-    property of the dummy-wave logic, not something suppression introduced,
-    but it has to be fixed in the scheduler before these instances can be
-    suppressed.
+``state_changed=True`` sends ``pass -1``: this pass altered scheduler
+    state, so it is not idempotent and re-asking is not a wasted question.
+    The three DP-barrier passes do that -- joining a round with a dummy,
+    joining it with a real batch, or handing a batch claim back -- and none
+    of them is preceded by a report, so nothing else would lift the
+    suppression. ASTRA-Sim treats it like a workload assignment: this NPU
+    stays askable and every other one is re-opened too.
     """
-    if not suppressible:
+    if state_changed:
         return "pass -1"
     nxt = router.get_next_pending_arrival()
     if nxt is None or nxt <= current:
@@ -814,7 +812,8 @@ def main():
                     controller.write_flush(p, workload)
                     responded = True
                 else:
-                    controller.write_flush(p, _pass_response(router, current, suppressible=False))
+                    # Joined the round with a dummy; the round is not complete.
+                    controller.write_flush(p, _pass_response(router, current, state_changed=True))
                     responded = True
         # runnable batch exists
         elif new_req is not None:
@@ -892,7 +891,7 @@ def main():
                         controller.write_flush(p, workload)
                     else:
                         # Waiting for other DP members — send pass
-                        controller.write_flush(p, _pass_response(router, current, suppressible=False))
+                        controller.write_flush(p, _pass_response(router, current, state_changed=True))
                         responded = True
                 else:
                     # Independent instance: generate trace immediately
@@ -940,7 +939,7 @@ def main():
                     waiting_request[instance_id] = False
                 if instance_id in inst_dp_group and new_req.workload_name is None:
                     new_req.fired.remove(sys)
-                    controller.write_flush(p, _pass_response(router, current, suppressible=False))
+                    controller.write_flush(p, _pass_response(router, current, state_changed=True))
                     responded = True
                 else:
                     workload = get_workload(new_req, instances[instance_id]["hardware"], instance_id,
@@ -1081,7 +1080,7 @@ def main():
                 if not all_dp_empty:
                     # Other DP members still have work — keep this instance alive for dummy waves
                     if not responded:
-                        controller.write_flush(p, _pass_response(router, current, suppressible=False))
+                        controller.write_flush(p, _pass_response(router, current))
                     flush.stdout.flush()
                     continue
 
@@ -1114,9 +1113,7 @@ def main():
             # advance current time so the next iteration can pick them up.
             # Built before the jump below: _pass_response compares against
             # the clock ASTRA-Sim is actually at, not the one we skip to.
-            pass_msg = _pass_response(
-                router, current,
-                suppressible=instance_id not in inst_dp_group)
+            pass_msg = _pass_response(router, current)
             if router.has_deferred_sessions() or router.has_pending_requests():
                 next_arrival = router.get_next_pending_arrival()
                 if next_arrival is not None and next_arrival > current:

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -342,10 +342,19 @@ def main():
     parser.add_argument('--inputs-root', type=str, default=None,
                         help='override the root directory for generated ASTRA-Sim inputs. Defaults to '
                         'astra-sim/inputs/runs/<run-id>')
-    parser.add_argument('--cleanup-inputs', action=argparse.BooleanOptionalAction, default=True,
-                        help='remove generated ASTRA-Sim inputs under astra-sim/inputs/runs/<run-id> '
-                        'after a successful simulation (default: enabled). Use --no-cleanup-inputs '
-                        'to preserve generated trace files, Chakra workloads, and input configs for debugging')
+    parser.add_argument('--save-trace-text', action=argparse.BooleanOptionalAction, default=False,
+                        help='write each batch\'s trace as text, for inspection (default: '
+                        'disabled). Nothing in the pipeline reads it -- the Chakra converter takes '
+                        'the trace rows directly -- so it is produced only on request, and it is '
+                        'the only human-readable form of what the simulator emitted. Implies '
+                        '--keep-inputs, since the text is written into the run directory. Can '
+                        'leave gigabytes behind on a long run')
+    parser.add_argument('--keep-inputs', action=argparse.BooleanOptionalAction, default=False,
+                        help='keep the generated ASTRA-Sim inputs under '
+                        'astra-sim/inputs/runs/<run-id> after a successful simulation (default: '
+                        'disabled). Preserves the Chakra .et workloads and the generated network, '
+                        'system and memory configs, so a run can be replayed through ASTRA-Sim by '
+                        'hand. Replaces --cleanup-inputs, whose polarity was inverted')
     parser.add_argument('--skip-prefill', action='store_true', default=False,
                         help='skip the prefill phase, running decode only')
     parser.add_argument('--num-reqs', type=int, default=0,
@@ -604,10 +613,10 @@ def main():
         event_time = first_arival_time
     else:
         event_time = INTERVAL
-    generate_event(int(event_time), inputs_root=run_paths.inputs_root)
+    event_trace = generate_event(int(event_time), inputs_root=run_paths.inputs_root)
     # Make Chakra Grapth
     generate_graph(None, None, total_npu, event=True, inputs_root=run_paths.inputs_root,
-                   cleanup_trace=args.cleanup_inputs)
+                   save_trace_text=args.save_trace_text, trace=event_trace)
     # set first workload file
     workload = get_workload(None, None, event=True, inputs_root=run_paths.inputs_root)
     # run subprocess
@@ -783,7 +792,7 @@ def main():
                                        inst_cfg["enable_local_offloading"],
                                        workload_name=dp_workload_name,
                                        inputs_root=run_paths.inputs_root,
-                                       cleanup_trace=args.cleanup_inputs,
+                                       save_trace_text=args.save_trace_text,
                                        trace=trace_data)
                         if inst_id != instance_id:
                             dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
@@ -861,7 +870,7 @@ def main():
                                            inst_cfg["enable_local_offloading"],
                                            workload_name=dp_workload_name,
                                            inputs_root=run_paths.inputs_root,
-                                           cleanup_trace=args.cleanup_inputs,
+                                           save_trace_text=args.save_trace_text,
                                            trace=trace_data)
                             if inst_id != instance_id:
                                 dp_ready_workloads[inst_id] = get_workload(batch, inst["hardware"], inst_id,
@@ -897,7 +906,7 @@ def main():
                                    instance_id, inst2npu_mapping[instance_id],
                                    inst_cfg["enable_local_offloading"],
                                    inputs_root=run_paths.inputs_root,
-                                   cleanup_trace=args.cleanup_inputs,
+                                   save_trace_text=args.save_trace_text,
                                    trace=trace_data)
                     workload = get_workload(new_req, instance["hardware"], instance_id,
                                             inputs_root=run_paths.inputs_root)
@@ -1205,7 +1214,9 @@ def main():
         for i in range(num_instances):
             schedulers[i].save_output(output_file, is_append=False if i == 0 else True)
 
-    if args.cleanup_inputs:
+    # --save-trace-text writes the text into the run directory, so keeping it
+    # is implied: producing the text and then deleting it would be pointless.
+    if not (args.keep_inputs or args.save_trace_text):
         _cleanup_inputs_root(run_paths, logger)
     
 

--- a/serving/__main__.py
+++ b/serving/__main__.py
@@ -62,6 +62,35 @@ def _pad_batch_to_max(batch, max_len):
     batch.num_decode += pad              # counted for lm_head / dense shape
 
 
+def _pass_response(router, current, suppressible=True):
+    """The "pass" answer, carrying the next known arrival when there is one.
+
+    ASTRA-Sim stops re-asking an NPU that passed until either some NPU
+    reports an iteration the frontend has not processed yet, or this
+    deadline is reached. Those are the only two things that can change what
+    ``schedule()`` returns, so suppressing the re-asks in between skips no
+    decision. Without the deadline an idle instance would stay suppressed
+    past an arrival it should have admitted, in the case where every other
+    instance is still mid-batch and so no report is coming.
+
+    ``suppressible=False`` sends ``pass -1``, which opts the NPU out. That
+    is required for DP-group instances, where being polled is itself part
+    of the model: an idle member emits a 1-token dummy batch so the round's
+    ALLTOALL still syncs, so the poll rate decides how many dummy waves
+    exist. Suppressing them moved moe_dp_pp by -4.0% (578 batches -> 572)
+    and moe_dp_tp_pp by +0.14%. That poll-rate dependence is a pre-existing
+    property of the dummy-wave logic, not something suppression introduced,
+    but it has to be fixed in the scheduler before these instances can be
+    suppressed.
+    """
+    if not suppressible:
+        return "pass -1"
+    nxt = router.get_next_pending_arrival()
+    if nxt is None or nxt <= current:
+        return "pass"
+    return f"pass {int(nxt)}"
+
+
 def _runtime_limit(value):
     return float('inf') if value == 0 else value
 
@@ -776,7 +805,7 @@ def main():
                     controller.write_flush(p, workload)
                     responded = True
                 else:
-                    controller.write_flush(p, "pass")
+                    controller.write_flush(p, _pass_response(router, current, suppressible=False))
                     responded = True
         # runnable batch exists
         elif new_req is not None:
@@ -853,7 +882,7 @@ def main():
                         controller.write_flush(p, workload)
                     else:
                         # Waiting for other DP members — send pass
-                        controller.write_flush(p, "pass")
+                        controller.write_flush(p, _pass_response(router, current, suppressible=False))
                         responded = True
                 else:
                     # Independent instance: generate trace immediately
@@ -900,7 +929,7 @@ def main():
                     waiting_request[instance_id] = False
                 if instance_id in inst_dp_group and new_req.workload_name is None:
                     new_req.fired.remove(sys)
-                    controller.write_flush(p, "pass")
+                    controller.write_flush(p, _pass_response(router, current, suppressible=False))
                     responded = True
                 else:
                     workload = get_workload(new_req, instances[instance_id]["hardware"], instance_id,
@@ -1041,7 +1070,7 @@ def main():
                 if not all_dp_empty:
                     # Other DP members still have work — keep this instance alive for dummy waves
                     if not responded:
-                        controller.write_flush(p, "pass")
+                        controller.write_flush(p, _pass_response(router, current, suppressible=False))
                     flush.stdout.flush()
                     continue
 
@@ -1072,11 +1101,16 @@ def main():
             # If all instances are idle but deferred sessions have pending
             # requests with future arrival times (tool calls still running),
             # advance current time so the next iteration can pick them up.
+            # Built before the jump below: _pass_response compares against
+            # the clock ASTRA-Sim is actually at, not the one we skip to.
+            pass_msg = _pass_response(
+                router, current,
+                suppressible=instance_id not in inst_dp_group)
             if router.has_deferred_sessions() or router.has_pending_requests():
                 next_arrival = router.get_next_pending_arrival()
                 if next_arrival is not None and next_arrival > current:
                     current = next_arrival
-            controller.write_flush(p, "pass")
+            controller.write_flush(p, pass_msg)
         
         # flush
         flush.stdout.flush()

--- a/serving/core/controller.py
+++ b/serving/core/controller.py
@@ -1,6 +1,15 @@
 import re
 from .logger import get_logger
 
+# ASTRA-Sim's per-iteration report, the one line of its stdout the frontend
+# has to parse. Compiled once: parse_output runs on every handshake, and at
+# 8 NPUs a 10-request run makes 337,786 of them.
+_ITERATION_RE = re.compile(
+    r"sys\[(\d+)\] iteration (\d+) finished, (\d+) cycles, "
+    r"exposed communication (\d+) cycles."
+)
+
+
 class Controller():
     def __init__(self, total_num):
         self.end_dict = {}
@@ -11,13 +20,19 @@ class Controller():
 
 
     def read_wait(self, p):
+        """Read ASTRA-Sim's stdout up to the "Waiting" prompt.
+
+        Every line before the prompt is the iteration report; ASTRA-Sim used
+        to interleave a per-tick "Checking ..." line per NPU, which made this
+        loop 3.07M reads on a 10-request 8-NPU run against 675k now. See the
+        ASTRA_SIM_TRACE_POLLING note in the analytical backend's main.cc.
+        """
         out = [""]
         while "Waiting" not in out[-1] and out[-1] != "Checking Non-Exited Systems ...\n":
             line = p.stdout.readline()
             # For debugging
             # print(line, end='')
             out.append(line)
-            p.stdout.flush()
         return out
 
     def check_end(self, p):
@@ -37,8 +52,7 @@ class Controller():
         return
 
     def parse_output(self, output):
-        pattern = r"sys\[(\d+)\] iteration (\d+) finished, (\d+) cycles, exposed communication (\d+) cycles."
-        match = re.search(pattern, output)
+        match = _ITERATION_RE.search(output)
         if match:
             sys = int(match.group(1))
             id = int(match.group(2))

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -7,6 +7,7 @@ from time import time
 from .request import *
 from .logger import get_logger
 from .run_paths import input_path
+from .trace_generator import write_trace
 
 logger = get_logger("GraphGenerator")
 
@@ -50,6 +51,22 @@ _ET_SEEN_MAX = 200_000
 def graph_cache_stats():
     """Hit/miss counts for the converted-graph cache."""
     return dict(_ET_CACHE_STATS, entries=len(_ET_CACHE), bytes=_ET_CACHE_BYTES)
+
+
+def _rows_digest(trace):
+    """Digest a synthesized trace without formatting it.
+
+    Keyed on the same content the formatter would emit -- the header line and
+    every field of every row, in order -- but joined with separators instead
+    of padded into columns, which is far cheaper than the real format and
+    just as discriminating. Cryptographic rather than ``hash()`` because a
+    collision here would silently hand back the wrong graph.
+    """
+    h = hashlib.blake2b(digest_size=16)
+    h.update(trace.header_line.encode())
+    h.update(b"\n")
+    h.update("\n".join("\t".join(row) for row in trace.rows).encode())
+    return h.hexdigest()
 
 
 def _et_names(workload_dir):
@@ -119,7 +136,7 @@ def _get_llm_converter():
     return _LLMConverter
 
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, in_process=True, reuse_graphs=True):
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, in_process=True, reuse_graphs=True, trace=None):
 
     cwd = os.getcwd()
     chakra = os.path.join(cwd, "extern/graph_frontend/chakra")
@@ -141,8 +158,13 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
 
     cache_key = None
     if reuse_graphs:
-        with open(trace_path, "rb") as f:
-            digest = hashlib.blake2b(f.read(), digest_size=16).hexdigest()
+        if trace is not None:
+            digest = _rows_digest(trace)
+        else:
+            # The event-handler trace is written straight to disk by
+            # generate_event, so there are no rows to hash.
+            with open(trace_path, "rb") as f:
+                digest = hashlib.blake2b(f.read(), digest_size=16).hexdigest()
         cache_key = (digest, num_npus, npu_offset, enable_local_offloading)
         cached = _ET_CACHE.get(cache_key)
         if cached is not None:
@@ -153,13 +175,23 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
             for name, blob in cached:
                 with open(os.path.join(workload_dir, name), "wb") as g:
                     g.write(blob)
-            if cleanup_trace:
+            # A hit never needs the text: nothing is going to parse it. Write
+            # it only when the caller is keeping the intermediate artifacts
+            # for inspection.
+            if trace is not None:
+                if not cleanup_trace:
+                    write_trace(trace)
+            elif cleanup_trace:
                 try:
                     os.remove(trace_path)
                 except FileNotFoundError:
                     pass
             return
         _ET_CACHE_STATS["miss"] += 1
+
+    # The converter reads the trace as text, so it has to exist from here on.
+    if trace is not None:
+        write_trace(trace)
 
     before = _et_names(workload_dir) if cache_key is not None else None
 

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -7,7 +7,43 @@ from .run_paths import input_path
 
 logger = get_logger("GraphGenerator")
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True):
+# Chakra's LLMConverter, imported once and reused for the whole run.
+#
+# This used to be `python -m chakra.src.converter.converter LLM ...` in a
+# fresh subprocess per batch. Measured on the sim container, that cost
+# ~56 ms per call, of which ~52 ms was interpreter startup plus the
+# protobuf import and ~1.3 ms was the actual conversion — which made
+# graph generation 73-85% of simulator wall-clock across every config
+# profiled (1 NPU, 8 NPUs, and MoE DP+EP alike).
+#
+# Calling the converter in-process is safe because it keeps *all* of its
+# mutable state on the instance (`next_node_id`, `next_comm_tag`,
+# `comm_tag_dict`) — there is no module-level state to leak between
+# batches, so a fresh LLMConverter per batch is equivalent to a fresh
+# process. Verified byte-identical over 146 `.et` files.
+#
+# The import resolves to the *installed* chakra in site-packages, exactly
+# as the subprocess did (there is no `chakra/` package inside the chakra
+# repo root, so cwd never mattered). Editing the tree still requires
+# `pip3 install .` to take effect — see AGENTS.md.
+_LLMConverter = None
+
+
+def _get_llm_converter():
+    """Import LLMConverter on first use and cache the class.
+
+    Deferred rather than imported at module scope so a broken or
+    not-yet-installed chakra fails at the same point in the run as it did
+    with the subprocess, instead of at simulator import time.
+    """
+    global _LLMConverter
+    if _LLMConverter is None:
+        from chakra.src.converter.llm_converter import LLMConverter
+        _LLMConverter = LLMConverter
+    return _LLMConverter
+
+
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, in_process=True):
 
     cwd = os.getcwd()
     chakra = os.path.join(cwd, "extern/graph_frontend/chakra")
@@ -27,20 +63,29 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
     workload_dir = os.path.dirname(output_path)
     os.makedirs(workload_dir, exist_ok=True)
 
-    cmd = [
-        'python', '-m', 'chakra.src.converter.converter', 'LLM',
-        '--input', trace_path,
-        '--output', output_path,
-        '--num-npus', str(num_npus),
-        '--npu-offset', str(npu_offset),
-    ]
+    if in_process:
+        logger.debug("Converting graph in-process: %s -> %s", trace_path, output_path,
+                     extra={"node_id": node_id, "instance_id": instance_id})
+        converter = _get_llm_converter()(
+            trace_path, output_path, num_npus, npu_offset, enable_local_offloading,
+        )
+        converter.convert()
+    else:
+        cmd = [
+            'python', '-m', 'chakra.src.converter.converter', 'LLM',
+            '--input', trace_path,
+            '--output', output_path,
+            '--num-npus', str(num_npus),
+            '--npu-offset', str(npu_offset),
+        ]
 
-    if enable_local_offloading:
-        cmd.append('--local-offloading')
+        if enable_local_offloading:
+            cmd.append('--local-offloading')
 
-    logger.debug("Generating graph with command: %s", " ".join(cmd), extra={"node_id": node_id, "instance_id": instance_id})
+        logger.debug("Generating graph with command: %s", " ".join(cmd), extra={"node_id": node_id, "instance_id": instance_id})
 
-    subprocess.run(cmd, cwd=chakra, text=True, check=True)
+        subprocess.run(cmd, cwd=chakra, text=True, check=True)
+
     if cleanup_trace:
         try:
             os.remove(trace_path)

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -7,7 +7,7 @@ from time import time
 from .request import *
 from .logger import get_logger
 from .run_paths import input_path
-from .trace_generator import write_trace
+from .trace_generator import indexed_cols, write_trace
 
 logger = get_logger("GraphGenerator")
 
@@ -189,8 +189,11 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
             return
         _ET_CACHE_STATS["miss"] += 1
 
-    # The converter reads the trace as text, so it has to exist from here on.
-    if trace is not None:
+    # The in-process converter takes the rows directly; only the subprocess,
+    # and the event-handler trace that generate_event writes itself, need the
+    # text. Write it anyway when the caller is keeping the artifacts.
+    rows_path = trace is not None and in_process
+    if trace is not None and (not rows_path or not cleanup_trace):
         write_trace(trace)
 
     before = _et_names(workload_dir) if cache_key is not None else None
@@ -201,7 +204,10 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
         converter = _get_llm_converter()(
             trace_path, output_path, num_npus, npu_offset, enable_local_offloading,
         )
-        converter.convert()
+        if rows_path:
+            converter.convert_rows(trace.header_line, indexed_cols(trace.rows))
+        else:
+            converter.convert()
     else:
         cmd = [
             'python', '-m', 'chakra.src.converter.converter', 'LLM',

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -1,7 +1,6 @@
 import glob
 import hashlib
 import os
-import subprocess
 from collections import OrderedDict
 from time import time
 from .request import *
@@ -107,7 +106,8 @@ def _cache_store(key, paths):
 # ~56 ms per call, of which ~52 ms was interpreter startup plus the
 # protobuf import and ~1.3 ms was the actual conversion — which made
 # graph generation 73-85% of simulator wall-clock across every config
-# profiled (1 NPU, 8 NPUs, and MoE DP+EP alike).
+# profiled (1 NPU, 8 NPUs, and MoE DP+EP alike). The subprocess path is
+# gone; `git log` has it if it is ever needed to isolate a converter crash.
 #
 # Calling the converter in-process is safe because it keeps *all* of its
 # mutable state on the instance (`next_node_id`, `next_comm_tag`,
@@ -115,10 +115,9 @@ def _cache_store(key, paths):
 # batches, so a fresh LLMConverter per batch is equivalent to a fresh
 # process. Verified byte-identical over 146 `.et` files.
 #
-# The import resolves to the *installed* chakra in site-packages, exactly
-# as the subprocess did (there is no `chakra/` package inside the chakra
-# repo root, so cwd never mattered). Editing the tree still requires
-# `pip3 install .` to take effect — see AGENTS.md.
+# The import resolves to the *installed* chakra in site-packages, not the
+# checked-out tree, so editing the tree requires `pip3 install .` to take
+# effect — see AGENTS.md.
 _LLMConverter = None
 
 
@@ -126,8 +125,8 @@ def _get_llm_converter():
     """Import LLMConverter on first use and cache the class.
 
     Deferred rather than imported at module scope so a broken or
-    not-yet-installed chakra fails at the same point in the run as it did
-    with the subprocess, instead of at simulator import time.
+    not-yet-installed chakra fails when a graph is first converted, rather
+    than at simulator import time.
     """
     global _LLMConverter
     if _LLMConverter is None:
@@ -136,10 +135,9 @@ def _get_llm_converter():
     return _LLMConverter
 
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, in_process=True, reuse_graphs=True, trace=None):
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, trace=None):
 
     cwd = os.getcwd()
-    chakra = os.path.join(cwd, "extern/graph_frontend/chakra")
     if inputs_root is None:
         inputs_root = os.path.join(cwd, "inputs")
 
@@ -156,76 +154,56 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
     workload_dir = os.path.dirname(output_path)
     os.makedirs(workload_dir, exist_ok=True)
 
-    cache_key = None
-    if reuse_graphs:
-        if trace is not None:
-            digest = _rows_digest(trace)
-        else:
-            # The event-handler trace is written straight to disk by
-            # generate_event, so there are no rows to hash.
-            with open(trace_path, "rb") as f:
-                digest = hashlib.blake2b(f.read(), digest_size=16).hexdigest()
-        cache_key = (digest, num_npus, npu_offset, enable_local_offloading)
-        cached = _ET_CACHE.get(cache_key)
-        if cached is not None:
-            _ET_CACHE.move_to_end(cache_key)
-            _ET_CACHE_STATS["hit"] += 1
-            logger.debug("Graph cache hit for %s", trace_path,
-                         extra={"node_id": node_id, "instance_id": instance_id})
-            for name, blob in cached:
-                with open(os.path.join(workload_dir, name), "wb") as g:
-                    g.write(blob)
-            # A hit never needs the text: nothing is going to parse it. Write
-            # it only when the caller is keeping the intermediate artifacts
-            # for inspection.
-            if trace is not None:
-                if not cleanup_trace:
-                    write_trace(trace)
-            elif cleanup_trace:
-                try:
-                    os.remove(trace_path)
-                except FileNotFoundError:
-                    pass
-            return
-        _ET_CACHE_STATS["miss"] += 1
+    if trace is not None:
+        digest = _rows_digest(trace)
+    else:
+        # The event-handler trace is written straight to disk by
+        # generate_event, so there are no rows to hash.
+        with open(trace_path, "rb") as f:
+            digest = hashlib.blake2b(f.read(), digest_size=16).hexdigest()
+    cache_key = (digest, num_npus, npu_offset, enable_local_offloading)
 
-    # The in-process converter takes the rows directly; only the subprocess,
-    # and the event-handler trace that generate_event writes itself, need the
-    # text. Write it anyway when the caller is keeping the artifacts.
-    rows_path = trace is not None and in_process
-    if trace is not None and (not rows_path or not cleanup_trace):
+    cached = _ET_CACHE.get(cache_key)
+    if cached is not None:
+        _ET_CACHE.move_to_end(cache_key)
+        _ET_CACHE_STATS["hit"] += 1
+        logger.debug("Graph cache hit for %s", trace_path,
+                     extra={"node_id": node_id, "instance_id": instance_id})
+        for name, blob in cached:
+            with open(os.path.join(workload_dir, name), "wb") as g:
+                g.write(blob)
+        # A hit never needs the text: nothing is going to parse it. Write it
+        # only when the caller is keeping the intermediate artifacts.
+        if trace is not None:
+            if not cleanup_trace:
+                write_trace(trace)
+        elif cleanup_trace:
+            try:
+                os.remove(trace_path)
+            except FileNotFoundError:
+                pass
+        return
+    _ET_CACHE_STATS["miss"] += 1
+
+    # The converter takes the rows directly. Only the event-handler trace,
+    # which generate_event writes to disk itself, arrives as text -- and the
+    # caller may want the text kept for inspection either way.
+    if trace is not None and not cleanup_trace:
         write_trace(trace)
 
-    before = _et_names(workload_dir) if cache_key is not None else None
+    before = _et_names(workload_dir)
 
-    if in_process:
-        logger.debug("Converting graph in-process: %s -> %s", trace_path, output_path,
-                     extra={"node_id": node_id, "instance_id": instance_id})
-        converter = _get_llm_converter()(
-            trace_path, output_path, num_npus, npu_offset, enable_local_offloading,
-        )
-        if rows_path:
-            converter.convert_rows(trace.header_line, indexed_cols(trace.rows))
-        else:
-            converter.convert()
+    logger.debug("Converting graph: %s -> %s", trace_path, output_path,
+                 extra={"node_id": node_id, "instance_id": instance_id})
+    converter = _get_llm_converter()(
+        trace_path, output_path, num_npus, npu_offset, enable_local_offloading,
+    )
+    if trace is not None:
+        converter.convert_rows(trace.header_line, indexed_cols(trace.rows))
     else:
-        cmd = [
-            'python', '-m', 'chakra.src.converter.converter', 'LLM',
-            '--input', trace_path,
-            '--output', output_path,
-            '--num-npus', str(num_npus),
-            '--npu-offset', str(npu_offset),
-        ]
+        converter.convert()
 
-        if enable_local_offloading:
-            cmd.append('--local-offloading')
-
-        logger.debug("Generating graph with command: %s", " ".join(cmd), extra={"node_id": node_id, "instance_id": instance_id})
-
-        subprocess.run(cmd, cwd=chakra, text=True, check=True)
-
-    if cache_key is not None:
-        _cache_store(cache_key, _et_names(workload_dir) - before)
+    _cache_store(cache_key, _et_names(workload_dir) - before)
 
     if cleanup_trace:
         try:

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -135,7 +135,7 @@ def _get_llm_converter():
     return _LLMConverter
 
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, trace=None):
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, save_trace_text=False, *, trace):
 
     cwd = os.getcwd()
     if inputs_root is None:
@@ -154,14 +154,13 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
     workload_dir = os.path.dirname(output_path)
     os.makedirs(workload_dir, exist_ok=True)
 
-    if trace is not None:
-        digest = _rows_digest(trace)
-    else:
-        # The event-handler trace is written straight to disk by
-        # generate_event, so there are no rows to hash.
-        with open(trace_path, "rb") as f:
-            digest = hashlib.blake2b(f.read(), digest_size=16).hexdigest()
-    cache_key = (digest, num_npus, npu_offset, enable_local_offloading)
+    # Every trace arrives as rows now, the event handler's included, so the
+    # text is never an input -- only an artifact somebody asked for.
+    if save_trace_text:
+        write_trace(trace)
+
+    cache_key = (_rows_digest(trace), num_npus, npu_offset,
+                 enable_local_offloading)
 
     cached = _ET_CACHE.get(cache_key)
     if cached is not None:
@@ -172,24 +171,8 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
         for name, blob in cached:
             with open(os.path.join(workload_dir, name), "wb") as g:
                 g.write(blob)
-        # A hit never needs the text: nothing is going to parse it. Write it
-        # only when the caller is keeping the intermediate artifacts.
-        if trace is not None:
-            if not cleanup_trace:
-                write_trace(trace)
-        elif cleanup_trace:
-            try:
-                os.remove(trace_path)
-            except FileNotFoundError:
-                pass
         return
     _ET_CACHE_STATS["miss"] += 1
-
-    # The converter takes the rows directly. Only the event-handler trace,
-    # which generate_event writes to disk itself, arrives as text -- and the
-    # caller may want the text kept for inspection either way.
-    if trace is not None and not cleanup_trace:
-        write_trace(trace)
 
     before = _et_names(workload_dir)
 
@@ -198,16 +181,7 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
     converter = _get_llm_converter()(
         trace_path, output_path, num_npus, npu_offset, enable_local_offloading,
     )
-    if trace is not None:
-        converter.convert_rows(trace.header_line, indexed_cols(trace.rows))
-    else:
-        converter.convert()
+    converter.convert_rows(trace.header_line, indexed_cols(trace.rows))
 
     _cache_store(cache_key, _et_names(workload_dir) - before)
-
-    if cleanup_trace:
-        try:
-            os.remove(trace_path)
-        except FileNotFoundError:
-            pass
     return

--- a/serving/core/graph_generator.py
+++ b/serving/core/graph_generator.py
@@ -1,11 +1,87 @@
+import glob
+import hashlib
 import os
 import subprocess
+from collections import OrderedDict
 from time import time
 from .request import *
 from .logger import get_logger
 from .run_paths import input_path
 
 logger = get_logger("GraphGenerator")
+
+# ----------------------------------------------------------------------
+# Content-addressed cache of converted graphs.
+#
+# A DP group whose members are unevenly loaded spends half its waves on
+# dummy batches: an idle member emits a 1-token placeholder so the round's
+# ALLTOALL still has a partner, and _pad_batch_to_max then inflates it to
+# the group's max, so its trace is the same shape and cost as a real one.
+# On the swe-bench MoE DP+EP example that is 4,405 of 8,810 batches -- and
+# only 22 of those 4,405 traces are distinct, with one accounting for
+# 4,382. Converting that same graph 4,382 times cost ~12 s of a 63 s run.
+#
+# Keyed on the trace bytes plus every other input the converter reads
+# (num_npus, npu_offset, local_offloading -- its whole CLI surface besides
+# the paths), so a hit is byte-identical to a miss by construction. The
+# PREFILL path writes two files per rank and both land next to each other,
+# so the cache stores whatever `llm.*.et` a conversion produced rather
+# than assuming a count.
+#
+# Held as bytes rather than paths because each DP wave needs its own copy:
+# ASTRA-Sim is handed one folder per wave and every member reads its own
+# `llm.<npu>.et` out of it.
+# ----------------------------------------------------------------------
+_ET_CACHE = OrderedDict()          # key -> [(basename, bytes), ...]
+_ET_CACHE_BYTES = 0
+_ET_CACHE_MAX_BYTES = 64 * 1024 * 1024
+_ET_CACHE_STATS = {"hit": 0, "miss": 0, "skipped": 0}
+
+# Traces seen exactly once. A graph is only worth holding after it repeats:
+# most *real* batches produce a unique trace (3,482 distinct out of 4,405 on
+# the swe-bench MoE DP+EP example), and caching those on first sight filled
+# 64 MB with entries that were never read again, evicting the dummy-wave
+# graph that actually repeats. Storing on second sight costs one extra
+# conversion per distinct trace and keeps the cache to what earns its keep.
+_ET_SEEN = OrderedDict()
+_ET_SEEN_MAX = 200_000
+
+
+def graph_cache_stats():
+    """Hit/miss counts for the converted-graph cache."""
+    return dict(_ET_CACHE_STATS, entries=len(_ET_CACHE), bytes=_ET_CACHE_BYTES)
+
+
+def _et_names(workload_dir):
+    return set(glob.glob(os.path.join(workload_dir, "llm.*.et")))
+
+
+def _cache_store(key, paths):
+    """Read the freshly converted files into the cache, evicting LRU.
+
+    Only caches a trace that has been seen before; see _ET_SEEN.
+    """
+    global _ET_CACHE_BYTES
+    if key not in _ET_SEEN:
+        _ET_SEEN[key] = None
+        while len(_ET_SEEN) > _ET_SEEN_MAX:
+            _ET_SEEN.popitem(last=False)
+        return
+    entry = []
+    total = 0
+    for path in sorted(paths):
+        with open(path, "rb") as f:
+            blob = f.read()
+        entry.append((os.path.basename(path), blob))
+        total += len(blob)
+    if not entry or total > _ET_CACHE_MAX_BYTES:
+        _ET_CACHE_STATS["skipped"] += 1
+        return
+    _ET_CACHE[key] = entry
+    _ET_CACHE_BYTES += total
+    while _ET_CACHE_BYTES > _ET_CACHE_MAX_BYTES and len(_ET_CACHE) > 1:
+        _, evicted = _ET_CACHE.popitem(last=False)
+        _ET_CACHE_BYTES -= sum(len(b) for _, b in evicted)
 
 # Chakra's LLMConverter, imported once and reused for the whole run.
 #
@@ -43,7 +119,7 @@ def _get_llm_converter():
     return _LLMConverter
 
 
-def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, in_process=True):
+def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offset=0, enable_local_offloading=False, event=False, workload_name=None, inputs_root=None, cleanup_trace=True, in_process=True, reuse_graphs=True):
 
     cwd = os.getcwd()
     chakra = os.path.join(cwd, "extern/graph_frontend/chakra")
@@ -62,6 +138,30 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
     output_path = input_path(inputs_root, "workload", output_name, "llm")
     workload_dir = os.path.dirname(output_path)
     os.makedirs(workload_dir, exist_ok=True)
+
+    cache_key = None
+    if reuse_graphs:
+        with open(trace_path, "rb") as f:
+            digest = hashlib.blake2b(f.read(), digest_size=16).hexdigest()
+        cache_key = (digest, num_npus, npu_offset, enable_local_offloading)
+        cached = _ET_CACHE.get(cache_key)
+        if cached is not None:
+            _ET_CACHE.move_to_end(cache_key)
+            _ET_CACHE_STATS["hit"] += 1
+            logger.debug("Graph cache hit for %s", trace_path,
+                         extra={"node_id": node_id, "instance_id": instance_id})
+            for name, blob in cached:
+                with open(os.path.join(workload_dir, name), "wb") as g:
+                    g.write(blob)
+            if cleanup_trace:
+                try:
+                    os.remove(trace_path)
+                except FileNotFoundError:
+                    pass
+            return
+        _ET_CACHE_STATS["miss"] += 1
+
+    before = _et_names(workload_dir) if cache_key is not None else None
 
     if in_process:
         logger.debug("Converting graph in-process: %s -> %s", trace_path, output_path,
@@ -85,6 +185,9 @@ def generate_graph(batch, hardware, num_npus, node_id=0, instance_id=0, npu_offs
         logger.debug("Generating graph with command: %s", " ".join(cmd), extra={"node_id": node_id, "instance_id": instance_id})
 
         subprocess.run(cmd, cwd=chakra, text=True, check=True)
+
+    if cache_key is not None:
+        _cache_store(cache_key, _et_names(workload_dir) - before)
 
     if cleanup_trace:
         try:

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -1707,18 +1707,41 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
     if stage_boundaries:
         header_line += "\t\tpp_stage_boundaries: " + ",".join(str(b) for b in stage_boundaries)
 
-    _write_trace(output_path, header_line, mem + rows)
-    return
+    # The rows go to generate_graph rather than to disk. It hashes them for
+    # the converted-graph cache, and only a cache miss needs the text file at
+    # all -- so on a hit nothing is formatted and nothing is written. Writing
+    # it here unconditionally cost 0.616 ms per batch, 8,810 times on the
+    # swe-bench MoE DP+EP example, for a file that was then read straight
+    # back in the same process.
+    return TraceData(header_line=header_line, rows=mem + rows, path=output_path)
 
 
 # ======================================================================
 # Trace file writer
 # ======================================================================
 
+@dataclass
+class TraceData:
+    """A synthesized trace, before it is turned into text.
+
+    ``rows`` are field tuples straight from the emitters: eleven fields for a
+    layer, one for an EXPERT/PIM marker. ``path`` is where the ``.txt`` goes
+    if anything asks for it.
+    """
+    header_line: str
+    rows: list
+    path: str
+
+
 _TRACE_ROW_FIELDS = 11
 
 # One-shot guard, see _write_trace.
 _row_format_checked = False
+
+
+def write_trace(trace):
+    """Materialise a TraceData as the text file the Chakra converter reads."""
+    _write_trace(trace.path, trace.header_line, trace.rows)
 
 
 def _write_trace(output_path, header_line, rows):

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -269,14 +269,31 @@ def _read_category_csv(path, key_cols):
 
 
 def _build_1d_table(df, layer_col, key_col):
-    """Dense / per-sequence: per-layer sorted (keys, values) table."""
+    """Dense / per-sequence: per-layer sorted (keys, values) table.
+
+    Built from column lists in one pass rather than through
+    ``groupby``/``sort_values``/``drop_duplicates``. pandas spends roughly
+    37 us per row on that path, which put the attention table alone at
+    ~693 ms per ``tp<N>/`` folder; the same construction in plain Python
+    is ~9 ms and yields an identical structure.
+
+    Duplicate keys resolve last-wins. That is deterministic, where the
+    pandas path was not: ``sort_values`` defaults to an unstable
+    quicksort, so which of two rows sharing a key survived
+    ``drop_duplicates`` was unspecified. No bundle under
+    ``profiler/perf/`` currently carries a duplicate key in any category,
+    so this changes no existing lookup; for a CSV that gained rows from a
+    partial re-profile, last-wins takes the newer measurement.
+    """
+    grouped = {}
+    for layer, key, val in zip(df[layer_col].tolist(),
+                               df[key_col].astype(int).tolist(),
+                               df["latency_ns"].astype(int).tolist()):
+        grouped.setdefault(str(layer), {})[key] = val
     out = {}
-    for layer, g in df.groupby(layer_col):
-        g = g.sort_values(key_col).drop_duplicates(subset=[key_col])
-        out[str(layer)] = {
-            "keys": g[key_col].astype(int).tolist(),
-            "values": g["latency_ns"].astype(int).tolist(),
-        }
+    for layer, by_key in grouped.items():
+        keys = sorted(by_key)
+        out[layer] = {"keys": keys, "values": [by_key[k] for k in keys]}
     return out
 
 
@@ -287,24 +304,30 @@ def _build_attention_table(df):
     in log-space on each axis (plus a zero-pinned fallback when the
     axis value is 0, which always comes from an exact sample).
     """
-    pc_vals = sorted({int(v) for v in df["prefill_chunk"].tolist()})
-    nd_vals = sorted({int(v) for v in df["n_decode"].tolist()})
+    pc_col = df["prefill_chunk"].astype(int).tolist()
+    nd_col = df["n_decode"].astype(int).tolist()
+    kp_col = df["kv_prefill"].astype(int).tolist()
+    kd_col = df["kv_decode"].astype(int).tolist()
+    lat_col = df["latency_ns"].astype(int).tolist()
+
+    # (prefill_chunk, n_decode) -> kv_prefill -> kv_decode -> latency_ns.
+    # One pass in plain Python; see _build_1d_table for why not groupby.
+    grouped = {}
+    for pc, nd, kp, kd, lat in zip(pc_col, nd_col, kp_col, kd_col, lat_col):
+        grouped.setdefault((pc, nd), {}).setdefault(kp, {})[kd] = lat
+
     slices = {}
-    for (pc, nd), g in df.groupby(["prefill_chunk", "n_decode"]):
-        slice_tbl = {}
-        for kp, g2 in g.groupby("kv_prefill"):
-            g2 = g2.sort_values("kv_decode").drop_duplicates(subset=["kv_decode"])
-            slice_tbl[int(kp)] = {
-                "keys": g2["kv_decode"].astype(int).tolist(),
-                "values": g2["latency_ns"].astype(int).tolist(),
-            }
-        kp_vals_s = sorted(slice_tbl.keys())
-        slices[(int(pc), int(nd))] = {
-            "kv_prefill_vals": kp_vals_s,
-            "rows": [slice_tbl[kp] for kp in kp_vals_s],
-        }
+    for key, by_kp in grouped.items():
+        kp_vals_s = sorted(by_kp)
+        rows = []
+        for kp in kp_vals_s:
+            by_kd = by_kp[kp]
+            kd_keys = sorted(by_kd)
+            rows.append({"keys": kd_keys, "values": [by_kd[k] for k in kd_keys]})
+        slices[key] = {"kv_prefill_vals": kp_vals_s, "rows": rows}
+
     return {
-        "pc_vals": pc_vals, "nd_vals": nd_vals,
+        "pc_vals": sorted(set(pc_col)), "nd_vals": sorted(set(nd_col)),
         "pc_nd_pairs": sorted(slices.keys()),
         "slices": slices,
     }
@@ -312,16 +335,18 @@ def _build_attention_table(df):
 
 def _build_moe_table(df):
     """MoE table: (tokens, activated_experts) → latency_ns."""
-    tokens_by_experts = {}
-    for ae, g in df.groupby("activated_experts"):
-        g = g.sort_values("tokens").drop_duplicates(subset=["tokens"])
-        tokens_by_experts[int(ae)] = {
-            "keys": g["tokens"].astype(int).tolist(),
-            "values": g["latency_ns"].astype(int).tolist(),
-        }
-    ae_vals = sorted(tokens_by_experts.keys())
-    return {"activated_experts_vals": ae_vals,
-            "rows": [tokens_by_experts[a] for a in ae_vals]}
+    grouped = {}
+    for ae, tok, lat in zip(df["activated_experts"].astype(int).tolist(),
+                            df["tokens"].astype(int).tolist(),
+                            df["latency_ns"].astype(int).tolist()):
+        grouped.setdefault(ae, {})[tok] = lat
+    ae_vals = sorted(grouped)
+    rows = []
+    for ae in ae_vals:
+        by_tok = grouped[ae]
+        tok_keys = sorted(by_tok)
+        rows.append({"keys": tok_keys, "values": [by_tok[k] for k in tok_keys]})
+    return {"activated_experts_vals": ae_vals, "rows": rows}
 
 
 def _load_perf_db(hardware, model, variant, tp_needed, model_type):
@@ -346,36 +371,14 @@ def _load_perf_db(hardware, model, variant, tp_needed, model_type):
     meta = _load_meta(root)
     _hydrate_skew_fit_tables(meta, root)
     arch = _load_architecture(model_type)
-    tables_per_tp = {}
     available_tps = []
     for entry in sorted(os.listdir(root)):
         if not entry.startswith("tp"):
             continue
         try:
-            tp = int(entry[2:])
+            available_tps.append(int(entry[2:]))
         except ValueError:
             continue
-        tp_dir = os.path.join(root, entry)
-        tables = {}
-
-        dense_df = _read_category_csv(os.path.join(tp_dir, "dense.csv"), None)
-        if dense_df is not None:
-            tables["dense"] = _build_1d_table(dense_df, "layer", "tokens")
-
-        per_seq_df = _read_category_csv(os.path.join(tp_dir, "per_sequence.csv"), None)
-        if per_seq_df is not None:
-            tables["per_sequence"] = _build_1d_table(per_seq_df, "layer", "sequences")
-
-        attn_df = _read_category_csv(os.path.join(tp_dir, "attention.csv"), None)
-        if attn_df is not None:
-            tables["attention"] = _build_attention_table(attn_df)
-
-        moe_df = _read_category_csv(os.path.join(tp_dir, "moe.csv"), None)
-        if moe_df is not None:
-            tables["moe"] = _build_moe_table(moe_df)
-
-        tables_per_tp[tp] = tables
-        available_tps.append(tp)
 
     perf_db = {
         "meta": meta,
@@ -383,8 +386,10 @@ def _load_perf_db(hardware, model, variant, tp_needed, model_type):
         "variant": variant,
         "hardware": hardware,
         "model": model,
+        "root": root,
         "available_tps": sorted(available_tps),
-        "tables": tables_per_tp,
+        # Per-TP category tables, filled in by _tp_tables on first lookup.
+        "tables": {},
     }
     _perf_db_cache[cache_key] = perf_db
     _check_tp_coverage(perf_db, tp_needed, hardware, model, variant)
@@ -471,17 +476,54 @@ def _lookup_1d(keys, values, query):
     return _linear_interpolate(keys[lo], values[lo], keys[hi], values[hi], query)
 
 
+def _build_tp_tables(tp_dir):
+    """Build every category table present in one ``tp<N>/`` folder."""
+    tables = {}
+    dense_df = _read_category_csv(os.path.join(tp_dir, "dense.csv"), None)
+    if dense_df is not None:
+        tables["dense"] = _build_1d_table(dense_df, "layer", "tokens")
+
+    per_seq_df = _read_category_csv(os.path.join(tp_dir, "per_sequence.csv"), None)
+    if per_seq_df is not None:
+        tables["per_sequence"] = _build_1d_table(per_seq_df, "layer", "sequences")
+
+    attn_df = _read_category_csv(os.path.join(tp_dir, "attention.csv"), None)
+    if attn_df is not None:
+        tables["attention"] = _build_attention_table(attn_df)
+
+    moe_df = _read_category_csv(os.path.join(tp_dir, "moe.csv"), None)
+    if moe_df is not None:
+        tables["moe"] = _build_moe_table(moe_df)
+    return tables
+
+
 def _tp_tables(perf_db, tp):
-    """Fetch the category-table dict for a given TP degree, with a
-    clear error if the TP wasn't profiled.
+    """Fetch the category-table dict for a given TP degree, building it on
+    first use, with a clear error if the TP wasn't profiled.
+
+    Lazy because a bundle may carry many ``tp<N>/`` folders while one run
+    touches at most two of them: its own TP degree, plus tp1 for the
+    ``tp_stable`` layers and for MoE, which are profiled once at tp=1 (see
+    _effective_tp and _lookup_moe). Building every folder up front cost
+    ~700 ms per folder that the run never queried.
+
+    Every caller reaches the tables through here, so a lazily-built folder
+    is indistinguishable from an eagerly-built one. That matters for
+    _layer_available in particular: it used to read perf_db["tables"]
+    directly with a {} default, which under lazy building would have
+    reported a present layer as missing and silently skipped emitting it.
     """
     tables = perf_db["tables"].get(tp)
-    if tables is None:
+    if tables is not None:
+        return tables
+    if tp not in perf_db["available_tps"]:
         raise KeyError(
             f"No profile data for tp={tp} on {perf_db['hardware']}/"
             f"{perf_db['model']}/{perf_db['variant']}; available: "
             f"{perf_db['available_tps']}"
         )
+    tables = _build_tp_tables(os.path.join(perf_db["root"], f"tp{tp}"))
+    perf_db["tables"][tp] = tables
     return tables
 
 
@@ -1177,7 +1219,7 @@ def _layer_available(perf_db, tp, layer_name):
     if category is None:
         return False
     tp_eff = _effective_tp(perf_db, category, layer_name, tp)
-    tables = perf_db["tables"].get(tp_eff, {})
+    tables = _tp_tables(perf_db, tp_eff)
     if category == "dense":
         return layer_name in tables.get("dense", {})
     if category == "per_sequence":

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -1739,6 +1739,35 @@ _TRACE_ROW_FIELDS = 11
 _row_format_checked = False
 
 
+def indexed_cols(rows):
+    """The field lists the Chakra converter sees after parsing the trace text.
+
+    Mirrors _write_trace's two cases. A layer row gets its final row index
+    appended to the name and keeps its ten other fields. A marker row becomes
+    the tokens of its text -- which is how it comes back today, once the
+    formatter has padded it into the name column and the reader has split the
+    line on whitespace.
+
+    Kept beside _write_trace because the two have to agree exactly: the index
+    is positional and depends on the kv_load/kv_evict rows already sitting at
+    the front. Their agreement is not assumed -- the graphs built from each
+    path are byte-compared.
+    """
+    out = []
+    for i, row in enumerate(rows):
+        if len(row) == _TRACE_ROW_FIELDS:
+            out.append([f'{row[0]}_{i}', *row[1:]])
+        elif len(row) == 1:
+            out.append(row[0].split())
+        else:
+            raise ValueError(
+                f"trace row {i} has {len(row)} fields; expected "
+                f"{_TRACE_ROW_FIELDS} for a layer row or 1 for a marker. "
+                f"Row: {row!r}"
+            )
+    return out
+
+
 def write_trace(trace):
     """Materialise a TraceData as the text file the Chakra converter reads."""
     _write_trace(trace.path, trace.header_line, trace.rows)

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -1,5 +1,4 @@
 import os
-import re
 from .request import *
 from .utils import *
 import pandas as pd
@@ -1026,7 +1025,8 @@ def _emit_layer(ctx, bctx, layer_name, lines, power_acc, batch_tag='NONE', layer
 
     wt_loc = get_device(ctx.placement, layer_num, layer_name, "weights")
 
-    lines.append(formatter(layer_name, str(latency_ns), input_loc, str(inp), wt_loc, str(wt), output_loc, str(out), comm_type, str(comm_size), batch_tag))
+    lines.append((layer_name, str(latency_ns), input_loc, str(inp), wt_loc,
+                  str(wt), output_loc, str(out), comm_type, str(comm_size), batch_tag))
 
     if power_acc is not None:
         power_acc.npu_latencies_ns.append(latency_ns)
@@ -1078,13 +1078,13 @@ def _with_dim(comm_type, involved_dim):
 def _emit_pim_attention(ctx, bctx, lines, power_acc, layer_num, batch_tag='NONE'):
     """Emit PIM attention for decode requests across PIM channels."""
     for ch in range(ctx.pim_channels):
-        lines.append(f"PIM {ch}\n")
+        lines.append((f"PIM {ch}",))
         for L in bctx.decode_lens[ch]:
             inp, _, out = calculate_sizes(ctx.model, "attention", L, pim=True, parallel=ctx.tp_size, fp=ctx.fp)
             inp //= bctx.channel_split
             out //= bctx.channel_split
             pim_lat = int(ctx.pim_model.get_pim_latency(ctx.n_head, ctx.kv_head, ctx.head_dim, L, bctx.channel_split))
-            lines.append(formatter("attention", str(pim_lat),
+            lines.append(("attention", str(pim_lat),
                 f'REMOTE:{ctx.node_id}.{ch}', str(inp),
                 get_device(ctx.placement, layer_num, "attention", "weights"), '0',
                 f'REMOTE:{ctx.node_id}.{ch}', str(out),
@@ -1092,7 +1092,7 @@ def _emit_pim_attention(ctx, bctx, lines, power_acc, layer_num, batch_tag='NONE'
             if power_acc is not None and pim_lat > 0:
                 power_acc.pim_latencies_ns.append(pim_lat)
                 power_acc.dram_weight_bytes += inp + out
-    lines.append("PIM END\n")
+    lines.append(("PIM END",))
 
 
 def _emit_npu_attention(ctx, bctx, lines, power_acc, layer_num, batch_tag='NONE'):
@@ -1161,9 +1161,9 @@ def _emit_moe_block(ctx, bctx, lines, power_acc, layer_num, batch_id_str, batch_
 
     for i in range(emit_ep):
         if i == 0:
-            lines.append(f"EXPERT {i} {dispatch_comm_type} {dispatch_comm_size}\n")
+            lines.append((f"EXPERT {i} {dispatch_comm_type} {dispatch_comm_size}",))
         else:
-            lines.append(f"EXPERT {i} NONE 0\n")
+            lines.append((f"EXPERT {i} NONE 0",))
 
         # ``local_tokens`` here is the per-rank workload after dispatch
         # — already scaled to this rank's real tokens (no DP-padding sum).
@@ -1177,7 +1177,7 @@ def _emit_moe_block(ctx, bctx, lines, power_acc, layer_num, batch_id_str, batch_
                 ctx.model, "moe", local_tokens, parallel=ep_total, fp=ctx.fp)
             max_rank_latency_ns = max(max_rank_latency_ns, rank_latency_ns)
 
-            lines.append(formatter("expert", str(rank_latency_ns), 'LOCAL', str(rank_inp),
+            lines.append(("expert", str(rank_latency_ns), 'LOCAL', str(rank_inp),
                 wt_loc, str(rank_wt), 'LOCAL', str(rank_out), 'NONE', '0', batch_tag))
 
             if power_acc is not None and wt_loc != 'LOCAL':
@@ -1187,7 +1187,7 @@ def _emit_moe_block(ctx, bctx, lines, power_acc, layer_num, batch_id_str, batch_
     if power_acc is not None and max_rank_latency_ns > 0:
         power_acc.npu_latencies_ns.append(max_rank_latency_ns)
 
-    lines.append(f"EXPERT END {combine_comm_type} {combine_comm_size}\n")
+    lines.append((f"EXPERT END {combine_comm_type} {combine_comm_size}",))
 
     # Post-expert ReduceScatter power (combine)
     if power_acc is not None and ep_total > 1:
@@ -1334,18 +1334,16 @@ def _layer_latency_for_power(ctx, bctx, layer_name):
     return _lookup_dense(ctx.perf_db, layer_name, ctx.tp_size, bctx.total_len)
 
 
-def _emit_final_layers(ctx, bctx, f, batch_tag='NONE'):
+def _emit_final_layers(ctx, bctx, rows, batch_tag='NONE'):
     """Emit the architecture's head layers (final_layernorm, lm_head,
     sampler — ordered per the yaml) and feed them into the power model.
     The last emitted layer routes its output to REMOTE so the Chakra
     converter places a MEM_STORE node back to CPU.
     """
     head_layers = _sequence(ctx.perf_db, "head")
-    lines = []
     for i, layer_name in enumerate(head_layers):
         output_loc = f'REMOTE:{ctx.node_id}' if i == len(head_layers) - 1 else 'LOCAL'
-        _emit_layer(ctx, bctx, layer_name, lines, None, batch_tag, output_loc=output_loc)
-    f.writelines(lines)
+        _emit_layer(ctx, bctx, layer_name, rows, None, batch_tag, output_loc=output_loc)
 
     if ctx.power_model is not None:
         for layer_name in head_layers:
@@ -1373,7 +1371,7 @@ def _emit_pp_pd_power(ctx, bctx):
 # _synthesize_trace (non-interleaved)
 # ======================================================================
 
-def _emit_prologue(ctx, bctx, f, batch_tag='NONE'):
+def _emit_prologue(ctx, bctx, rows, batch_tag='NONE'):
     """Emit prologue layers (typically just embedding). The first layer's
     input is routed from REMOTE to match the Chakra converter's
     MEM_LOAD node placement.
@@ -1381,11 +1379,10 @@ def _emit_prologue(ctx, bctx, f, batch_tag='NONE'):
     prologue_layers = _sequence(ctx.perf_db, "prologue")
     if not prologue_layers:
         return 0
-    lines = []
+    before = len(rows)
     for i, layer_name in enumerate(prologue_layers):
         input_loc = f'REMOTE:{ctx.node_id}' if i == 0 else 'LOCAL'
-        _emit_layer(ctx, bctx, layer_name, lines, None, batch_tag, input_loc=input_loc)
-    f.writelines(lines)
+        _emit_layer(ctx, bctx, layer_name, rows, None, batch_tag, input_loc=input_loc)
     if ctx.power_model:
         for layer_name in prologue_layers:
             lat = _layer_latency_for_power(ctx, bctx, layer_name)
@@ -1394,11 +1391,11 @@ def _emit_prologue(ctx, bctx, f, batch_tag='NONE'):
             if get_device(ctx.placement, None, layer_name, "weights") != 'LOCAL':
                 _, wt, _ = calculate_sizes(ctx.model, layer_name, bctx.total_len, fp=ctx.fp)
                 ctx.power_model.add_dram_energy_consumption(ctx.node_id, wt)
-    return len(lines)
+    return len(rows) - before
 
 
 def _synthesize_trace(hardware, model, config, tp_size, pp_size, local_ep, ep_total, pd_type, node_id, instance_id,
-                      batch, max_len, output_path, placement, block_mode_on, gate,
+                      batch, max_len, placement, block_mode_on, gate,
                       enable_attn_offloading, power_model, pim_model, fp,
                       variant, kv_cache_dtype='auto',
                       runtime_max_num_batched_tokens=None, runtime_max_num_seqs=None,
@@ -1422,38 +1419,38 @@ def _synthesize_trace(hardware, model, config, tp_size, pp_size, local_ep, ep_to
     # pipeline stages on block boundaries (see _pp_stage_boundaries).
     block_starts = []
 
-    with open(output_path, 'w') as f:
-        written = _emit_prologue(ctx, bctx, f)
+    rows = []
+    written = _emit_prologue(ctx, bctx, rows)
 
-        # Transformer blocks
-        num_layers = config['num_hidden_layers']
-        iter_count, copy_count = (num_layers, 1) if block_mode_on else (1, num_layers)
+    # Transformer blocks
+    num_layers = config['num_hidden_layers']
+    iter_count, copy_count = (num_layers, 1) if block_mode_on else (1, num_layers)
 
-        for layer_num in range(iter_count):
-            block_lines, block_power = _build_transformer_block(ctx, bctx, layer_num, 'NONE', str(batch.batch_id))
+    for layer_num in range(iter_count):
+        block_lines, block_power = _build_transformer_block(ctx, bctx, layer_num, 'NONE', str(batch.batch_id))
 
-            # MoE blocks are only safely replayable when the router
-            # opts into block copy (BALANCED is deterministic; others
-            # carry tiny per-layer variance that block_copy swallows
-            # for the sake of trace-generation speed).
-            can_copy = (not ctx.is_moe or ctx.gate.block_copy) and not block_mode_on
-            if can_copy:
-                for _ in range(copy_count):
-                    block_starts.append(written)
-                    f.writelines(block_lines)
-                    written += len(block_lines)
-                    block_power.flush(ctx, enable_attn_offloading)
-            else:
+        # MoE blocks are only safely replayable when the router
+        # opts into block copy (BALANCED is deterministic; others
+        # carry tiny per-layer variance that block_copy swallows
+        # for the sake of trace-generation speed).
+        can_copy = (not ctx.is_moe or ctx.gate.block_copy) and not block_mode_on
+        if can_copy:
+            for _ in range(copy_count):
                 block_starts.append(written)
-                f.writelines(block_lines)
+                rows.extend(block_lines)
                 written += len(block_lines)
                 block_power.flush(ctx, enable_attn_offloading)
+        else:
+            block_starts.append(written)
+            rows.extend(block_lines)
+            written += len(block_lines)
+            block_power.flush(ctx, enable_attn_offloading)
 
-        # Final layers
-        _emit_final_layers(ctx, bctx, f)
-        _emit_pp_pd_power(ctx, bctx)
+    # Final layers
+    _emit_final_layers(ctx, bctx, rows)
+    _emit_pp_pd_power(ctx, bctx)
 
-    return block_starts
+    return rows, block_starts
 
 
 # ======================================================================
@@ -1461,7 +1458,7 @@ def _synthesize_trace(hardware, model, config, tp_size, pp_size, local_ep, ep_to
 # ======================================================================
 
 def _synthesize_interleaved_trace(hardware, model, config, tp_size, pp_size, local_ep, ep_total, pd_type, node_id, instance_id,
-                                  batches, max_len, output_path, placement, block_mode_on, gate,
+                                  batches, max_len, placement, block_mode_on, gate,
                                   enable_attn_offloading, power_model, pim_model, fp,
                                   variant, kv_cache_dtype='auto',
                                   runtime_max_num_batched_tokens=None, runtime_max_num_seqs=None,
@@ -1490,75 +1487,68 @@ def _synthesize_interleaved_trace(hardware, model, config, tp_size, pp_size, loc
 
     num_layers = config['num_hidden_layers']
 
-    with open(output_path, 'w') as f:
-        # PROLOGUE: Batch1 prologue + first pre-attn
-        _emit_prologue(ctx, bctx1, f, 'BATCH_1')
+    rows = []
 
-        pre_attn1_lines = []
-        pre_attn1_power = PowerAccumulator([], [], 0, 0)
-        _emit_pre_attn_layers(ctx, bctx1, 0, pre_attn1_lines, pre_attn1_power, 'BATCH_1')
-        f.writelines(pre_attn1_lines)
-        pre_attn1_power.flush(ctx, enable_attn_offloading)
+    # PROLOGUE: Batch1 prologue + first pre-attn
+    _emit_prologue(ctx, bctx1, rows, 'BATCH_1')
 
-        # Batch2 prologue + first pre-attn
-        _emit_prologue(ctx, bctx2, f, 'BATCH_2')
+    pre_attn1_power = PowerAccumulator([], [], 0, 0)
+    _emit_pre_attn_layers(ctx, bctx1, 0, rows, pre_attn1_power, 'BATCH_1')
+    pre_attn1_power.flush(ctx, enable_attn_offloading)
 
-        pre_attn2_lines = []
-        pre_attn2_power = PowerAccumulator([], [], 0, 0)
-        _emit_pre_attn_layers(ctx, bctx2, 0, pre_attn2_lines, pre_attn2_power, 'BATCH_2')
-        f.writelines(pre_attn2_lines)
-        pre_attn2_power.flush(ctx, enable_attn_offloading)
+    # Batch2 prologue + first pre-attn
+    _emit_prologue(ctx, bctx2, rows, 'BATCH_2')
 
-        # MIDDLE LAYERS: interleaved post_attn + pre_attn
-        middle_layers = num_layers - 1
-        iter_count, copy_count = (middle_layers, 1) if block_mode_on else (1, middle_layers)
+    pre_attn2_power = PowerAccumulator([], [], 0, 0)
+    _emit_pre_attn_layers(ctx, bctx2, 0, rows, pre_attn2_power, 'BATCH_2')
+    pre_attn2_power.flush(ctx, enable_attn_offloading)
 
-        for layer_num in range(iter_count):
-            block_lines = []
-            block_power = PowerAccumulator([], [], 0, 0)
+    # MIDDLE LAYERS: interleaved post_attn + pre_attn
+    middle_layers = num_layers - 1
+    iter_count, copy_count = (middle_layers, 1) if block_mode_on else (1, middle_layers)
 
-            # Batch1: post_attn(current) + pre_attn(next)
-            _emit_post_attn_layers(ctx, bctx1, layer_num, block_lines, block_power, f"{batches[0].batch_id}.0", 'BATCH_1')
-            _emit_pre_attn_layers(ctx, bctx1, layer_num + 1, block_lines, block_power, 'BATCH_1')
+    for layer_num in range(iter_count):
+        block_lines = []
+        block_power = PowerAccumulator([], [], 0, 0)
 
-            # Batch2: post_attn(current) + pre_attn(next)
-            _emit_post_attn_layers(ctx, bctx2, layer_num, block_lines, block_power, f"{batches[1].batch_id}.1", 'BATCH_2')
-            _emit_pre_attn_layers(ctx, bctx2, layer_num + 1, block_lines, block_power, 'BATCH_2')
+        # Batch1: post_attn(current) + pre_attn(next)
+        _emit_post_attn_layers(ctx, bctx1, layer_num, block_lines, block_power, f"{batches[0].batch_id}.0", 'BATCH_1')
+        _emit_pre_attn_layers(ctx, bctx1, layer_num + 1, block_lines, block_power, 'BATCH_1')
 
-            # MoE blocks are only safely replayable when the router
-            # opts into block copy (BALANCED is deterministic; others
-            # carry tiny per-layer variance that block_copy swallows
-            # for the sake of trace-generation speed).
-            can_copy = (not ctx.is_moe or ctx.gate.block_copy) and not block_mode_on
-            if can_copy:
-                for _ in range(copy_count):
-                    f.writelines(block_lines)
-                    block_power.flush(ctx, enable_attn_offloading)
-            else:
-                f.writelines(block_lines)
+        # Batch2: post_attn(current) + pre_attn(next)
+        _emit_post_attn_layers(ctx, bctx2, layer_num, block_lines, block_power, f"{batches[1].batch_id}.1", 'BATCH_2')
+        _emit_pre_attn_layers(ctx, bctx2, layer_num + 1, block_lines, block_power, 'BATCH_2')
+
+        # MoE blocks are only safely replayable when the router
+        # opts into block copy (BALANCED is deterministic; others
+        # carry tiny per-layer variance that block_copy swallows
+        # for the sake of trace-generation speed).
+        can_copy = (not ctx.is_moe or ctx.gate.block_copy) and not block_mode_on
+        if can_copy:
+            for _ in range(copy_count):
+                rows.extend(block_lines)
                 block_power.flush(ctx, enable_attn_offloading)
+        else:
+            rows.extend(block_lines)
+            block_power.flush(ctx, enable_attn_offloading)
 
-        # EPILOGUE: last layer post_attn + final layers
-        last_lines = []
-        last_power = PowerAccumulator([], [], 0, 0)
-        _emit_post_attn_layers(ctx, bctx1, num_layers - 1, last_lines, last_power, f"{batches[0].batch_id}.0", 'BATCH_1')
-        f.writelines(last_lines)
-        last_power.flush(ctx, enable_attn_offloading)
-        _emit_final_layers(ctx, bctx1, f, 'BATCH_1')
+    # EPILOGUE: last layer post_attn + final layers
+    last_power = PowerAccumulator([], [], 0, 0)
+    _emit_post_attn_layers(ctx, bctx1, num_layers - 1, rows, last_power, f"{batches[0].batch_id}.0", 'BATCH_1')
+    last_power.flush(ctx, enable_attn_offloading)
+    _emit_final_layers(ctx, bctx1, rows, 'BATCH_1')
 
-        last_lines2 = []
-        last_power2 = PowerAccumulator([], [], 0, 0)
-        _emit_post_attn_layers(ctx, bctx2, num_layers - 1, last_lines2, last_power2, f"{batches[1].batch_id}.1", 'BATCH_2')
-        f.writelines(last_lines2)
-        last_power2.flush(ctx, enable_attn_offloading)
-        _emit_final_layers(ctx, bctx2, f, 'BATCH_2')
+    last_power2 = PowerAccumulator([], [], 0, 0)
+    _emit_post_attn_layers(ctx, bctx2, num_layers - 1, rows, last_power2, f"{batches[1].batch_id}.1", 'BATCH_2')
+    last_power2.flush(ctx, enable_attn_offloading)
+    _emit_final_layers(ctx, bctx2, rows, 'BATCH_2')
 
-        _emit_pp_pd_power(ctx, bctx1)
+    _emit_pp_pd_power(ctx, bctx1)
 
     # Sub-batch interleaving leaves both sub-batches mid-block at every
     # group edge, so there is no single tensor to hand to the next stage.
     # generate_trace refuses the combination before we get here.
-    return []
+    return rows, []
 
 
 # ======================================================================
@@ -1671,11 +1661,11 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
                         runtime_max_num_seqs=max_num_seqs,
                         tp_dim=tp_dim, ep_dim=ep_dim, dp_sum_total_len=dp_sum_total_len)
     if not enable_sub_batch_interleaving:
-        block_starts = _synthesize_trace(*synth_args, batch, max_len, output_path, **synth_kwargs)
+        rows, block_starts = _synthesize_trace(*synth_args, batch, max_len, **synth_kwargs)
     else:
         batches = _make_sub_batch(batch)
         if len(batches) < 2 or len(batches[0].requests) == 0 or len(batches[1].requests) == 0:
-            block_starts = _synthesize_trace(*synth_args, batch, max_len, output_path, **synth_kwargs)
+            rows, block_starts = _synthesize_trace(*synth_args, batch, max_len, **synth_kwargs)
         else:
             if pp_size > 1:
                 raise ValueError(
@@ -1683,17 +1673,11 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
                     "an interleaved trace leaves both sub-batches mid-block at every "
                     "group edge, so a pipeline stage has no single hidden state to pass on"
                 )
-            block_starts = _synthesize_interleaved_trace(*synth_args, batches, max_len, output_path, **synth_kwargs)
+            rows, block_starts = _synthesize_interleaved_trace(*synth_args, batches, max_len, **synth_kwargs)
 
     stage_boundaries = _pp_stage_boundaries(block_starts, pp_size)
 
-    with open(output_path, 'r') as f:
-        dic = []
-        for line in f.readlines():
-            split = re.findall(r'\S+', line)
-            dic.append(split)
-
-    # vllm: open output txt file and add load, evict mem
+    # vllm: prepend the load / evict rows
     mem = []
     if load_size != 0:
         load = ["kv_load", '0', 'LOCAL', '0', get_device(placement, None, None, 'kv_evict_loc'), str(load_size), 'LOCAL', '0', 'NONE', '0', 'NONE']
@@ -1709,34 +1693,100 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
     if power_model is not None:
         power_model.print_log(node_id)
 
-    result = mem + dic
+    # instance type
+    if pd_type == None:
+        instance_type = 'COLOCATED'
+    elif pd_type == 'prefill':
+        instance_type = 'PREFILL'
+    elif pd_type == 'decode':
+        instance_type = 'DECODE'
+    else:
+        raise ValueError(f"Unknown instance type {pd_type}.")
+
+    header_line = f"{instance_type}\t\tmodel_parallel_NPU_group: {pp_size}"
+    if stage_boundaries:
+        header_line += "\t\tpp_stage_boundaries: " + ",".join(str(b) for b in stage_boundaries)
+
+    _write_trace(output_path, header_line, mem + rows)
+    return
+
+
+# ======================================================================
+# Trace file writer
+# ======================================================================
+
+_TRACE_ROW_FIELDS = 11
+
+# One-shot guard, see _write_trace.
+_row_format_checked = False
+
+
+def _write_trace(output_path, header_line, rows):
+    """Write the trace file in a single pass.
+
+    Rows arrive as field tuples straight from the emitters: eleven fields
+    for a layer, one for an ``EXPERT``/``PIM`` marker whose text occupies
+    the name column with the rest blank. Layer names get their final row
+    index appended here, and here only, because that index depends on how
+    many ``kv_load``/``kv_evict`` rows were prepended -- which is not known
+    until every row exists.
+
+    This replaces a write -> read back -> ``re.findall`` per line -> rewrite
+    round trip. The round trip existed purely to renumber, and it cost a
+    regex split per row on top of writing the file, reading it, and writing
+    it again. A 145-iteration run spent 42,341 ``re.findall`` calls on it.
+
+    Marker rows are told apart by field count rather than by the old
+    ``"EXPERT" not in name and "PIM" not in name`` substring test, which
+    would have mislabelled any future layer whose canonical name contained
+    either word.
+    """
+    global _row_format_checked
+
+    lines = []
+    for i, row in enumerate(rows):
+        if len(row) == _TRACE_ROW_FIELDS:
+            lines.append(formatter(f'{row[0]}_{i}', *row[1:]))
+        elif len(row) == 1:
+            lines.append(formatter(row[0], *([''] * 10)))
+        else:
+            raise ValueError(
+                f"trace row {i} has {len(row)} fields; expected "
+                f"{_TRACE_ROW_FIELDS} for a layer row or 1 for a marker. "
+                f"Row: {row!r}"
+            )
+
+    # Dropping the read-back also drops the place where a formatted row
+    # that had swallowed its own column separator used to surface -- as a
+    # short field list, which then raised a TypeError on the rewrite. That
+    # is how the 15-character ``ALLREDUCE:1,0,0`` case was caught. The
+    # explicit separators in utils._FMT now make a merge unrepresentable,
+    # so this is a regression guard on _FMT rather than the primary
+    # defence, and it runs on the *formatted* text because the field tuple
+    # is never the thing at fault: a correct 11-element row is exactly what
+    # formatting merged. Checking every row of every trace would cost a
+    # split per row and give back the speed this change bought, so it
+    # validates the first trace written in the process, which is enough to
+    # fail immediately on any run.
+    if not _row_format_checked:
+        _row_format_checked = True
+        for i, (row, line) in enumerate(zip(rows, lines)):
+            if len(row) != _TRACE_ROW_FIELDS:
+                continue
+            got = len(line.split())
+            if got != _TRACE_ROW_FIELDS:
+                raise ValueError(
+                    f"trace row {i} formatted to {got} whitespace-separated "
+                    f"fields instead of {_TRACE_ROW_FIELDS}: a value filled "
+                    f"its column and merged with the next. Widen the column "
+                    f"in utils._FMT. Row: {row!r}"
+                )
 
     with open(output_path, 'w') as f:
-        # instance type
-        if pd_type == None:
-            instance_type = 'COLOCATED'
-        elif pd_type == 'prefill':
-            instance_type = 'PREFILL'
-        elif pd_type == 'decode':
-            instance_type = 'DECODE'
-        else:
-            raise ValueError(f"Unknown instance type {pd_type}.")
-
-        header_line = f"{instance_type}\t\tmodel_parallel_NPU_group: {pp_size}"
-        if stage_boundaries:
-            header_line += "\t\tpp_stage_boundaries: " + ",".join(str(b) for b in stage_boundaries)
         f.write(header_line + "\n")
-        f.write(str(len(result))+'\n')
+        f.write(str(len(rows)) + '\n')
         f.write(header())
-
-        # add layer_number at the end of the layer_name
-        for i in range(0, len(result)):
-            if "EXPERT" not in result[i][0] and "PIM" not in result[i][0]:
-                new_string = f'{result[i][0]}_{i}'
-                f.write(formatter(new_string, *result[i][1:]))
-            else:
-                f.write(formatter(' '.join(result[i]),'','','','','','','','','',''))
-    return
+        f.writelines(lines)
 
 
 # ======================================================================

--- a/serving/core/trace_generator.py
+++ b/serving/core/trace_generator.py
@@ -1626,7 +1626,6 @@ def generate_trace(batch, hardware, tp_size, pp_size, local_ep, ep_total, pd_typ
         inputs_root, "trace", hardware, batch.model,
         f"instance{instance_id}_batch{batch.batch_id}.txt",
     )
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     # make trace — accept either the Mistral-style ``num_local_experts``
     # key or the HF/Qwen3 ``num_experts`` key so both family's configs
@@ -1769,7 +1768,13 @@ def indexed_cols(rows):
 
 
 def write_trace(trace):
-    """Materialise a TraceData as the text file the Chakra converter reads."""
+    """Materialise a TraceData as text, for inspection.
+
+    Nothing in the pipeline reads it any more -- the converter takes the rows
+    -- so this only runs when --save-trace-text asks for it. Creates the
+    directory because it is now the only thing that writes there.
+    """
+    os.makedirs(os.path.dirname(trace.path), exist_ok=True)
     _write_trace(trace.path, trace.header_line, trace.rows)
 
 
@@ -1848,34 +1853,26 @@ def _write_trace(output_path, header_line, rows):
 
 # generate event for first request arrival
 def generate_event(alarm, inputs_root=None):
+    """The one-layer trace that idles every NPU until ``alarm``.
 
-    # make inputs for text file
-    result = []
-    fp = 2
-    layer_name = f'event_{alarm}ns'
-    comp_time = alarm
-    input_loc = 'REMOTE'
-    input_size = 0
-    weight_loc = 'LOCAL'
-    weight_size = 0
-    output_loc = 'REMOTE'
-    output_size = 0
-    comm_type = 'NONE'
-    comm_size = 0
-    misc = 'NONE'
-    result.append([layer_name, comp_time, input_loc, input_size, weight_loc, weight_size, output_loc, output_size, comm_type, comm_size, misc])
+    Returns a TraceData like generate_trace, so generate_graph converts it
+    from rows like any other batch. It used to write its file directly, and
+    being the one trace that still arrived as text kept a whole second path
+    alive in generate_graph -- file hashing, ``convert()``, and a per-batch
+    unlink -- for a call that happens once per run.
 
-    # write to the text file
+    Fields are strings for the same reason the emitters produce strings: the
+    row digest joins them, and the text writer formats them.
+    """
     if inputs_root is None:
         inputs_root = os.path.join(os.getcwd(), "inputs")
-    output_path = input_path(inputs_root, "trace", "event_handler.txt")
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    with open(output_path, 'w') as f:
-        f.write(f"EVENT\n")
-        f.write(f'{len(result)}'+'\n') # length of the text is 1
-        f.write(header())
-        for i in result:
-            f.write(formatter(*i))
+    row = (f'event_{alarm}ns', str(alarm), 'REMOTE', '0', 'LOCAL', '0',
+           'REMOTE', '0', 'NONE', '0', 'NONE')
+    return TraceData(
+        header_line="EVENT",
+        rows=[row],
+        path=input_path(inputs_root, "trace", "event_handler.txt"),
+    )
 
 
 # ======================================================================

--- a/serving/core/utils.py
+++ b/serving/core/utils.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 from time import time
 import json
 
@@ -68,7 +69,18 @@ def formatter(layername, comp_time, input_loc, input_size, weight_loc, weight_si
     )
 
 
+@lru_cache(maxsize=None)
 def get_config(model_name):
+    """Load a model architecture config, cached for the process lifetime.
+
+    Cached because the hot path re-read and re-parsed the JSON on every
+    iteration -- generate_trace, the memory model's size helpers and the
+    DP-group scheduling block each call this per scheduled batch.
+
+    The cache hands every caller the *same* dict, so callers must treat it
+    as read-only. They do today: every use is a subscript, a ``.get`` or an
+    ``in`` test, and nothing assigns into it or mutates it in place.
+    """
     base_dir = os.path.dirname(os.path.abspath(__file__))
     serving_dir = os.path.dirname(base_dir)
     repo_root = os.path.dirname(serving_dir)


### PR DESCRIPTION
## What

Seventeen commits across `chakra`, `astra-sim` and `serving/`, each one measured and each one leaving simulation output unchanged.

On the four `bench/examples/` validation workloads (300 requests each), total wall-clock goes **16m 40s → 1m 26s**. Both sides measured on the same machine in the same session — `main` was checked out and rebuilt to get the "before" column rather than trusting the committed `sim.log` times:

| Example | before | after | |
|---|---|---|---|
| RTX4090 / Llama-3.1-8B | 6m 30.9s | **15.9s** | 24.6x |
| RTXPRO6000 / Llama-3.1-8B | 2m 36.8s | **9.6s** | 16.3x |
| RTXPRO6000 / Qwen3-30B-A3B | 4m 21.5s | **24.1s** | 10.8x |
| RTXPRO6000 / Qwen3-32B | 3m 11.0s | **36.6s** | 5.2x |

The 19 `serving/run.sh` scenarios go **18.95 min → 1.73 min**. The spread (5.2x to 24.6x) tracks how much of each run was Python overhead rather than ASTRA-Sim's own graph simulation — Qwen3-32B was always backend-bound, so there was less to remove.

## Correctness

This is the part worth reviewing. Every step was held to unchanged output, not to "close enough":

- **All 19 `serving/run.sh` scenarios produce identical `Total clocks (ns)`** — checked at every commit, not just at the end.
- **All four `bench/examples` `sim.csv` files are byte-identical**, so per-request TTFT / TPOT / latency against the recorded vLLM runs is unchanged to the bit. The committed validation numbers still hold exactly.
- Artifact-level byte comparisons wherever a change could plausibly alter them: 146/146 `.et` for the in-process converter; 1,477 traces + 3,534 `.et` for the single-pass writer; 4,066 `.et` for the rows-based conversion; 22/22 profile tables for the plain-Python builders.
- **Poll-rate independence is demonstrated, not assumed**: with idle-NPU suppression on and off — a 36x difference in polling frequency — all five DP configs produce identical clocks.

Two things did change, deliberately:

1. **`.et` bytes differ.** Graph metadata now stores the trace's path instead of its whole text. Nothing consumed it — `ETFeeder::readGlobalMetadata()` reads the message and discards it — and it was 70% of every file. Byte-comparing `.et` across this branch will show every file differing.
2. **Duplicate-key tie-break in the profile tables** went from pandas' unstable-sort-then-keep-first to last-wins. No bundle under `profiler/perf/` has a duplicate key in any category, so nothing changes today; the previous behaviour was unspecified.

One regression was introduced and caught mid-branch: the first version of the idle-NPU suppression diverged on 8 of 19 scenarios, because a workload assignment is a state change and did not bump the generation, so an instance's second TP rank joined its own batch late. Fixed in `a0c20837`.

## Surface area

`--cleanup-inputs` is replaced by two flags, both defaulting off — the same observable default as `--cleanup-inputs` defaulting on, without the double negative:

| | |
|---|---|
| `--save-trace-text` | write each batch's trace as text, for inspection. Nothing in the pipeline reads it, so it is produced only on request — and it is the only human-readable form of what the simulator emitted. Implies `--keep-inputs`. |
| `--keep-inputs` | keep `astra-sim/inputs/runs/<run-id>`: the `.et` workloads and the generated network / system / memory configs, so a run can be replayed through ASTRA-Sim by hand. |

The old flag was doing two unrelated jobs, which were only the same switch because the trace text used to be written unconditionally and then deleted. **Scripts passing `--no-cleanup-inputs` need one of the two instead.**

Verified by behaviour rather than only by clocks, on the `moe` scenario:

```
default            rundir gone   trace.txt 0     .et 0
--save-trace-text  rundir kept   trace.txt 155   .et 310
--keep-inputs      rundir kept   trace.txt 0     .et 310
```

with `Total clocks` 1945309759 in all three.

Nothing else was added. Two flags and two env vars existed mid-branch to guard the optimizations and were removed once each was verified byte-identical — a flag whose other setting is only slower is surface area, not a choice.

## The changes

1. **In-process Chakra converter.** The subprocess cost ~56 ms per batch — ~52 ms of interpreter startup and protobuf import against ~1.3 ms of actual conversion — which made graph generation 73-85% of wall-clock on every config profiled (1 NPU, 8 NPUs, MoE DP+EP alike).
2. **Rows instead of text.** The converter takes field tuples directly, via a new `LLMConverter.convert_rows()`. Formatting rows into padded columns, writing the file, reading it back and re-splitting every line is pure overhead once both sides share a process. `generate_event` was converted too, so the file-reading path is gone entirely and `generate_graph` is single-path.
3. **Converted-graph reuse.** A DP group with uneven load spends half its waves on dummy batches whose trace is nearly a constant: 4,405 of 8,810 batches on the swe-bench MoE DP+EP example, and only 22 of those 4,405 traces are distinct.
4. **Idle-NPU re-ask suppression.** 336,894 of 337,786 answers on a 10-request 8-NPU run were `pass`, and 336,890 of those were sent while another instance was mid-batch. Handshakes on that config drop 337,786 → 2,462.
5. **Per-tick polling trace removed.** The frontend had to read every `Checking NPU ...` line off the pipe before reaching the `Waiting` it was blocked on: 78% of lines read on a 10-request 8-NPU run, 99.6% on MoE DP+EP.
6. **Startup.** Profile tables are built in plain Python and only for the TP degrees a run touches (1435 ms → 50 ms for TP=1); the model architecture config is cached instead of re-parsed per scheduled batch.

## Protocol change

The Python → C++ direction gained two messages, documented in `architecture.mdx`:

- `pass <tick>` — nothing to run, and here is the next known request arrival. That is the one thing the backend cannot work out for itself.
- `pass -1` — this `pass` *changed* scheduler state (the three DP-barrier passes do), so it is not idempotent and is treated like a workload assignment: re-open every NPU.

**The frontend and the binary must match.** An older binary compares the answer to `"pass"` exactly and would read `pass 12345` as a workload path.

## How this was validated

These scripts already exist on `main` — they are what the branch was checked against, not something it adds:

```bash
# 19-scenario regression: Total clocks (ns) must match exactly
./serving/run.sh          # with each scenario uncommented in turn

# accuracy against the recorded vLLM runs
./bench/examples/run.sh && ./bench/examples/validate.sh
```

Output CSVs: `bench/examples/<hardware>/<model>/outputs/sim.csv`, byte-identical to `main`. Summaries under `.../validation/summary.txt`. `npm run build` in `docs/` succeeds, and Docusaurus fails on broken links, so the cross-references hold.

## Requires a rebuild

```bash
bash astra-sim/build/astra_analytical/build.sh
cd astra-sim/extern/graph_frontend/chakra && pip3 install .
```

Submodules are already pushed to `main`: `chakra` `c464cb0..30221ab`, `astra-sim` `e941257..d346994`.

## Docs

25 references updated. Four had been stale since before this branch: `AGENTS.md`'s key-data-flow diagram and trace-file-format section, `architecture.mdx` saying `graph_generator` "shells out" to the converter, and `trace-generation.md`'s flowchart ending at `trace .txt`.

## Not done

ASTRA-Sim rebuilds the ETFeeder graph from scratch every iteration (`delete et_feeder; new ETFeeder(file)`), which is 10.05 s of the 28.7 s backend time on the swe-bench MoE DP+EP example — and roughly half of those graphs are byte-identical repeats. Capturing it means caching parsed protobuf nodes inside `et_feeder.cpp`, a component shared with upstream and used by every workload type, for an estimated 6-8%. Left alone deliberately.

Also measured and rejected: making the trace rows carry native ints to skip the `int → str → int` round trip. It saves 0.23 s on `Layer` construction but costs 1.56 s stringifying for the row digest, which runs on every batch rather than only on cache misses — a net **1.33 s slower**.
