### PR TITLE
Stop asserting the scenario count in prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ LLMServingSim/
 │   │   ├── logger.py           # Rich-based logger + stdio capture
 │   │   └── utils.py            # Model config loading, formatting
 │   ├── run.sh                  # One runnable example per feature (a menu, not a suite)
-│   ├── validate.sh             # 58 scenarios vs recorded clocks + sim.csv digests
+│   ├── validate.sh             # every scenario vs recorded clocks + bench/examples digests
 │   └── validate-baselines.txt  # the recorded values; refresh with validate.sh --update
 ├── configs/
 │   ├── cluster/                # Cluster topology configs (hardware, memory, instances)
@@ -681,12 +681,13 @@ website (not the README).
 No unit-test suite. The simulator is deterministic, so validation is exact
 equality against recorded results:
 
-1. **`./serving/validate.sh`** — the whole check, ~8 min. Stage 1 compares 58
-   scenarios against the `Total clocks (ns)` recorded in
-   `serving/validate-baselines.txt`; stage 2 regenerates
-   `bench/examples/*/outputs/sim.csv` and checks each md5. Anything that moved
-   is printed as a markdown table for the PR. `--clocks-only` skips stage 2,
-   `--list` names the scenarios, `--update` rewrites the baselines.
+1. **`./serving/validate.sh`** — the whole check, ~8 min. Stage 1 compares every
+   scenario against the `Total clocks (ns)` recorded in
+   `serving/validate-baselines.txt`; stage 2 regenerates each `bench/examples`
+   entry's `outputs/sim.csv` and `validation/summary.txt` and checks both md5s.
+   Anything that moved is printed as a markdown table for the PR.
+   `--clocks-only` skips stage 2, `--list` names the scenarios, `--update`
+   rewrites the baselines, `--help` prints the rest.
    **Run it after every commit that touches `serving/`** — it is cheap enough,
    and it is how the 8-of-19 regression on the perf branch was caught.
 2. For the *size* of an accuracy change, not just its presence:

--- a/docs/docs/contributor/codebase-tour.md
+++ b/docs/docs/contributor/codebase-tour.md
@@ -175,7 +175,7 @@ instead, so validation is exact equality against recorded results:
 ./serving/validate.sh
 ```
 
-58 scenarios compared against recorded `Total clocks (ns)`, then each
+Every scenario compared against its recorded `Total clocks (ns)`, then each
 `bench/examples` entry's `sim.csv` and `validation/summary.txt` checked
 by md5. See **[Validating your changes](./validating-changes)** for
 what to do when something differs, and for the case where no scenario

--- a/docs/docs/contributor/validating-changes.md
+++ b/docs/docs/contributor/validating-changes.md
@@ -19,8 +19,8 @@ runs that comparison for you.
 
 Two stages, about eight minutes total:
 
-1. **Behaviour** — 58 scenarios, each compared against its recorded
-   `Total clocks (ns)` in `serving/validate-baselines.txt`. Every cluster
+1. **Behaviour** — every scenario in `serving/validate-baselines.txt`,
+   compared against its recorded `Total clocks (ns)`. Every cluster
    config, every parallelism shape (TP, PP, DP and their combinations, EP),
    prefix caching and the tiers below it, the scheduler flags, both routing
    policies, PIM, CXL, P/D disaggregation, agentic sessions and two hardware

--- a/serving/README.md
+++ b/serving/README.md
@@ -25,7 +25,7 @@ serving/                        Python package
 │   ├── logger.py               Rich-based logger + stdio capture
 │   └── utils.py                model config loading, formatting helpers
 ├── run.sh                      one runnable example per feature (a menu, not a suite)
-├── validate.sh                 58 scenarios vs recorded clocks + bench/examples digests
+├── validate.sh                 every scenario vs recorded clocks + bench/examples digests
 └── validate-baselines.txt      the recorded values; refresh with validate.sh --update
 ```
 
@@ -39,7 +39,7 @@ exact equality against recorded results:
 ./serving/validate.sh --help     # options
 ```
 
-Stage 1 compares 58 scenarios against the `Total clocks (ns)` in
+Stage 1 compares every scenario against the `Total clocks (ns)` in
 `validate-baselines.txt`. Stage 2 regenerates each `bench/examples` entry's
 `outputs/sim.csv` and `validation/summary.txt` and checks their md5s. Anything
 that moved is printed as a markdown table to paste into the PR — a difference


### PR DESCRIPTION
Missed the #68 merge by a few minutes — this is the one commit that didn't make it in. Docs and `AGENTS.md` wording only, no code.

Five places asserted "58 scenarios", which is a fact `serving/validate.sh` owns. It goes silently wrong the first time someone adds a scenario, and a reader takes prose as specification. They now say "every scenario", which cannot drift:

- `AGENTS.md` — the layout comment and the Testing & Validation section
- `serving/README.md` — the layout comment and the stage-1 sentence
- `docs/docs/contributor/validating-changes.md` — the stage-1 bullet
- `docs/docs/contributor/codebase-tour.md` — the "Tests and fixtures" section

Deliberately left carrying the number: the two occurrences inside a fenced output block, the one inside a blockquote showing what a contributor writes in a PR, and the CHANGELOG entry. Readers read terminal output and quoted examples as snapshots from one particular run, and a changelog entry is a dated record of what shipped. The undriftable reference already exists and the page points at it — `--list` and `--help` are generated on demand.

Also fixes `AGENTS.md`'s stage-2 description, which still said the accuracy stage digests `sim.csv` only; it also digests `validation/summary.txt` since #68.

Docs build clean, and `CHANGELOG.md` / `docs/src/pages/changelog.md` bodies verified identical.
