### PR TITLE
Fix every admonition on the docs site, and add a check for the class

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Build site
         run: pnpm build
 
+      # Also wired as a postbuild hook, but pnpm's enable-pre-post-scripts
+      # default has flipped between majors, so do not rely on it in CI.
+      - name: Check for unparsed markup in the built site
+        run: pnpm check-rendered
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 ## [Unreleased]
 
 ### Added
+- `docs/scripts/check-rendered.mjs` — scans the built site for source syntax that
+  survived into visible text (unparsed admonitions, bold, links, headings, table rows,
+  doubled list markers, visible HTML comments, JSX brace leaks). Runs as a `postbuild`
+  hook and as an explicit CI step, and exits non-zero. `pnpm check-rendered`.
 - `serving/validate.sh` — 58 scenarios checked against recorded total clocks, plus md5
   checks on each `bench/examples` entry's `outputs/sim.csv` and
   `validation/summary.txt`, and a markdown report of anything that moved, ready to paste
@@ -164,6 +168,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   the start NPU join. `ep_size` was irrelevant. The topology is now `[tp, pp, dp]`
   innermost-first, matching vLLM, with `pp` dropped when it is 1. Reported by
   [@hsule](https://github.com/hsule)
+- **Every admonition on the docs site rendered as raw text.** `:::caution Title` is
+  Docusaurus v2 syntax; v3 needs `:::caution[Title]`, and the bare form is not
+  recognised as a directive, so the block became a literal paragraph. 14 occurrences
+  across 13 pages, with no build warning. All bracketed, and
+  `docs/scripts/check-rendered.mjs` now fails the build on the whole class
 - `configs/cluster/rtx4090_tp2_instance.json` was documented as runnable in
   `configs/cluster/README.md` ("not validated", i.e. runs without ground truth) and in
   the examples table. It raises `FileNotFoundError`: only `tp1` is profiled for RTX4090.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 ### Added
 - `docs/scripts/check-rendered.mjs` — scans the built site for source syntax that
   survived into visible text (unparsed admonitions, bold, links, headings, table rows,
-  doubled list markers, visible HTML comments, JSX brace leaks). Runs as a `postbuild`
-  hook and as an explicit CI step, and exits non-zero. `pnpm check-rendered`.
+  doubled list markers, visible HTML comments, JSX brace leaks), plus a structural
+  check on every mermaid diagram — unknown type, empty, unbalanced `subgraph`/`end` —
+  read from the source, since theme-mermaid leaves nothing in the static HTML. Runs as
+  a `postbuild` hook and as an explicit CI step, and exits non-zero.
+  `pnpm check-rendered`.
 - `serving/validate.sh` — 58 scenarios checked against recorded total clocks, plus md5
   checks on each `bench/examples` entry's `outputs/sim.csv` and
   `validation/summary.txt`, and a markdown report of anything that moved, ready to paste

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -163,6 +163,38 @@ step is silently a no-op if the source is set to anything else.
   not full URLs. `onBrokenLinks: 'throw'` will fail the build on dead links.
 - **Component names**: PascalCase (`HomepageFeatures`).
 - **File naming**: `kebab-case.md` for docs, matches the URL slug.
+- **Admonitions**: the title goes in **brackets** — `:::caution[Title here]`,
+  closed by `:::`. The bare form `:::caution Title here` is Docusaurus v2 syntax:
+  v3 does not recognise it as a directive, so the whole block renders as a
+  literal paragraph starting `:::caution ...`. Nothing warns — not the build, not
+  `onBrokenLinks: 'throw'` — and it sat on 13 pages before anyone looked at the
+  rendered output. A titleless `:::note` needs no brackets.
+- **A fact the code owns does not go in prose.** Counts, file lists, flag sets,
+  defaults: if a script or config decides it, prose that repeats it goes silently
+  wrong the first time the code changes, and readers take prose as specification.
+  Write "every scenario in `serving/validate-baselines.txt`", not "58 scenarios".
+  Sample output and quoted examples are exempt — readers already read a terminal
+  block or a blockquote as a snapshot from one particular run. Point at the
+  generator instead of mirroring it: `--list` and `--help` cannot go stale.
+
+## Checks that run on the site
+
+- `pnpm build` runs two hooks around it. `prebuild` regenerates
+  `src/pages/changelog.md` from the repo-root `CHANGELOG.md`
+  (`scripts/sync-changelog.mjs`) — **edit `CHANGELOG.md` only**; the page is
+  generated, and committed so a fresh clone works. `postbuild` runs
+  `scripts/check-rendered.mjs`.
+- `scripts/check-rendered.mjs` scans the built HTML for source syntax that
+  survived into visible text — unparsed admonitions, bold, links, headings, table
+  rows, doubled list markers, visible HTML comments, JSX brace leaks. It strips
+  `<pre>`/`<code>`/`<script>` first, since syntax is legitimate there, and exits
+  non-zero on any hit. It exists because this whole class of bug is *not an
+  error*: markup Docusaurus cannot parse becomes text, so the only way to catch
+  it is to look at the output. Run it with `pnpm check-rendered` after a build.
+- **Not covered: mermaid.** Diagrams render client-side, so a broken one looks
+  fine in the built HTML and the scanner cannot see it. Checking them needs a DOM
+  (`mermaid.parse()` in bare node fails on `DOMPurify.addHook`). If you touch a
+  diagram, look at the page.
 
 ## Things explicitly **not** in scope yet
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -191,10 +191,17 @@ step is silently a no-op if the source is set to anything else.
   non-zero on any hit. It exists because this whole class of bug is *not an
   error*: markup Docusaurus cannot parse becomes text, so the only way to catch
   it is to look at the output. Run it with `pnpm check-rendered` after a build.
-- **Not covered: mermaid.** Diagrams render client-side, so a broken one looks
-  fine in the built HTML and the scanner cannot see it. Checking them needs a DOM
-  (`mermaid.parse()` in bare node fails on `DOMPurify.addHook`). If you touch a
-  diagram, look at the page.
+- **Mermaid is checked structurally, from the source.** theme-mermaid leaves no
+  `<pre class="mermaid">` in the static HTML — the diagram source goes into the JS
+  bundle and renders in the browser — so the HTML scan cannot see diagrams at all.
+  The checker reads the ```` ```mermaid ```` blocks out of the `.md`/`.mdx` files
+  instead and reports `file:line`. It catches an unknown diagram type, an empty
+  diagram, and a `subgraph` with no matching `end`.
+  **It is not mermaid's parser**, which needs a DOM even to parse
+  (`mermaid.parse()` in bare node fails on `DOMPurify.addHook`) and would mean a
+  `jsdom` dependency. So bad node syntax inside a structurally sound diagram, and
+  anything visual — overflow, colour contrast, a diagram that renders but says the
+  wrong thing — still needs you to open the page.
 
 ## Things explicitly **not** in scope yet
 

--- a/docs/docs/contributor/validating-changes.md
+++ b/docs/docs/contributor/validating-changes.md
@@ -85,7 +85,7 @@ If the change is intended, land the new truth in the same PR:
    that summary stale — leaving them behind publishes accuracy numbers for a
    simulator that no longer exists.
 
-:::caution A passing scenario is not proof your case is covered
+:::caution[A passing scenario is not proof your case is covered]
 `workloads/example_trace.jsonl` has 2–22 token prompts, so most scenarios
 never fill the KV cache and their DP members always drain together. That is
 why issue #65 survived a green `moe_dp_pp`: the bug needed one DP member to

--- a/docs/docs/examples/cluster-config-explained.mdx
+++ b/docs/docs/examples/cluster-config-explained.mdx
@@ -263,7 +263,7 @@ Llama-3.1-8B version of the same idea, and additionally overrides
 `long_prefill_token_threshold`, `block_size`, `dtype`, and
 `kv_cache_dtype`.
 
-:::caution `max_num_batched_tokens: 0` is not infinity
+:::caution[`max_num_batched_tokens: 0` is not infinity]
 `0` maps to "unlimited", but the scheduler then applies
 `min(max_num_batched_tokens, max_position_embeddings)`. On Qwen3-32B
 that is 40960, so the decode instance above runs at 40960, not

--- a/docs/docs/getting-started/installation/simulator.mdx
+++ b/docs/docs/getting-started/installation/simulator.mdx
@@ -99,7 +99,7 @@ ls -l astra-sim/build/astra_analytical/build/AnalyticalAstra/bin/AnalyticalAstra
 That is the exact path `serving/__main__.py` launches as a subprocess,
 so if it exists and is executable, the build worked.
 
-:::tip ns3 backend
+:::tip[ns3 backend]
 `compile.sh` has a commented-out block for the ns3 backend
 (packet-level network simulation). Most users don't need it. Uncomment
 it only if you intend to pass `--network-backend ns3`, which launches a

--- a/docs/docs/profiler/adding-hardware.md
+++ b/docs/docs/profiler/adding-hardware.md
@@ -192,7 +192,7 @@ sweep-bound warning.
 **not read at run time**, so you can omit them from a synthetic bundle
 or fill them in however you like.
 
-:::danger `alpha_default` does nothing without `enabled: true`
+:::danger[`alpha_default` does nothing without `enabled: true`]
 `_skew_alpha` returns the module fallback — which is **0**, i.e. no
 skew correction at all — unless `skew_fit.enabled` is truthy. So a
 bundle carrying `alpha_default: 0.3` but no `enabled` flag silently

--- a/docs/docs/profiler/skew-alpha-fit.md
+++ b/docs/docs/profiler/skew-alpha-fit.md
@@ -60,7 +60,7 @@ Alpha is a **normalized position on the t_mean → t_max line**:
 `t_max > t_mean` is required, else the row is recorded as `nan` and the
 fit skips it.
 
-:::info Alpha is not clamped to [0, 1]
+:::info[Alpha is not clamped to [0, 1]]
 The name says "normalized", but nothing bounds the ratio, and the
 measured data lands outside `[0, 1]` regularly. Across the six bundles
 in `profiler/perf/`, per `skew.csv`:

--- a/docs/docs/reference/bench-cli.md
+++ b/docs/docs/reference/bench-cli.md
@@ -60,7 +60,7 @@ comparison is not apples-to-apples.
 | `--kv-cache-dtype` | string | `auto` | vLLM `kv_cache_dtype` |
 | `--seed` | int | `42` | Sampling seed |
 
-:::note Defaults differ from `python -m serving`
+:::note[Defaults differ from `python -m serving`]
 `bench run` defaults `--dtype` to `bfloat16` outright, where the
 simulator resolves it from the model config's `torch_dtype`. `bench`
 also has no `--block-size`: vLLM picks the KV block size itself, and
@@ -153,7 +153,7 @@ The simulator's CSV exposes `arrival`, `end_time`, and a per-token ITL
 list directly; bench derives the same fields from vLLM's
 `RequestStateStats`.
 
-:::caution `prompt_throughput` is not comparable tick-for-tick
+:::caution[`prompt_throughput` is not comparable tick-for-tick]
 vLLM counts a prompt once, at prefill completion, so its
 `prompt_throughput` series cannot show preemption and recomputation.
 The simulator's per-tick prompt tokens can. Compare the per-request

--- a/docs/docs/reference/cli-flags.md
+++ b/docs/docs/reference/cli-flags.md
@@ -9,7 +9,7 @@ Complete reference for every command-line flag accepted by
 `python -m serving`. For the conceptual side of each flag (what it
 *does* internally), see **[Simulator](/docs/simulator/architecture)**.
 
-:::tip 14 of these can be set per instance
+:::tip[14 of these can be set per instance]
 Flags marked **(per-instance)** below can also be written into an
 individual `instances[i]` object in the cluster config, which wins over
 the CLI value for that instance only. That is how one run serves

--- a/docs/docs/reference/cluster-config.md
+++ b/docs/docs/reference/cluster-config.md
@@ -248,7 +248,7 @@ The other 13 are plain keys on the instance object. `mem_util` sits
 It must be a number in `(0, 1]` — it is a *fraction*, so `0.9`, never
 `90`. Anything else raises at startup rather than being clamped.
 
-:::caution Match it to a measured run when the KV cache saturates
+:::caution[Match it to a measured run when the KV cache saturates]
 `mem_util` sizes the KV cache, and that only shows up in the results once a run
 actually fills it — below the ceiling nothing is preempted and the capacity is
 invisible. On a card with headroom, leave it at the default.

--- a/docs/docs/reference/pim-config.md
+++ b/docs/docs/reference/pim-config.md
@@ -51,7 +51,7 @@ device total. How many channels a node has is derived from
 `DDR4_8GB_3200_pim` gets `512 / 8 = 64` channels and an aggregate
 `64 x 25.6 = 1638 GB/s`.
 
-:::warning Adding a fifth config takes a code change
+:::warning[Adding a fifth config takes a code change]
 `pim_model.py` matches the INI's **filename stem** against a
 hard-coded table of calibrated latency coefficients. A new `.ini`
 alone raises `ValueError: Unknown PIM spec: <stem>`. See

--- a/docs/docs/simulator/reading-output.md
+++ b/docs/docs/simulator/reading-output.md
@@ -301,7 +301,7 @@ Notes on individual fields:
 - The per-**Instance** blocks report **milliseconds**, unlike the CSV,
   which is nanoseconds throughout.
 
-:::note TTFT is not measured the way vLLM measures it
+:::note[TTFT is not measured the way vLLM measures it]
 The simulator stops the clock when the first token's *computation*
 completes. vLLM stops it when the client *receives* the token, so real
 vLLM TTFT is higher. `bench validate` puts both sides on matched

--- a/docs/docs/simulator/scheduling/kv-cache-and-memory.md
+++ b/docs/docs/simulator/scheduling/kv-cache-and-memory.md
@@ -134,7 +134,7 @@ Initialization** at startup:
   • Instance [0] : 585248 tokens / 36578 blocks (71.44 GiB/rank at util 0.90)
 ```
 
-:::caution Calibrate `mem_util` when the KV cache is the binding constraint
+:::caution[Calibrate `mem_util` when the KV cache is the binding constraint]
 `mem_util` only changes behaviour once a run actually **saturates** the KV
 cache. Below that, the pool never runs out, nothing is preempted, and the
 capacity you configured is invisible in the results. On a card with plenty of

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -32,7 +32,7 @@ Inputs and outputs (vLLM token IDs, sampling params, per-request
 timings) are pinned via `bench`'s strict-replay path so both runs
 process exactly the same prompts in the same order.
 
-:::caution Match `mem_util` to the real run whenever the KV cache saturates
+:::caution[Match `mem_util` to the real run whenever the KV cache saturates]
 `npu_mem.mem_util` sizes the KV cache, and KV cache size only shows up in the
 results once a run actually **fills** it — below that nothing is preempted and
 the capacity is invisible. Of the four configurations here, only the RTX 4090

--- a/docs/docs/workloads/sharegpt-generators.md
+++ b/docs/docs/workloads/sharegpt-generators.md
@@ -131,7 +131,7 @@ matching the model you'll run in the simulator:
 | `--vllm-temperature` | `0.0` | Sampling temperature. `0` = greedy, which makes generation reproducible for a given seed |
 | `--vllm-repetition-penalty` | `1.1` | Down-weights already-emitted tokens. `1.0` disables it |
 
-:::note Why the repetition penalty defaults above 1.0
+:::note[Why the repetition penalty defaults above 1.0]
 Free generation at `1.0` tends to ramble past the natural stopping
 point, so EOS never fires and every request runs to
 `--max-output-toks`. `1.1` keeps natural EOS landing at typical

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,9 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "check-rendered": "node scripts/check-rendered.mjs",
+    "postbuild": "node scripts/check-rendered.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.0",

--- a/docs/scripts/check-rendered.mjs
+++ b/docs/scripts/check-rendered.mjs
@@ -76,16 +76,85 @@ for (const file of htmlFiles) {
   }
 }
 
-console.log(`checked ${htmlFiles.length} built pages`);
-if (findings.size === 0) {
+// ---------------------------------------------------------------------------
+// Mermaid, checked against the *source* rather than the build.
+//
+// theme-mermaid does not leave a <pre class="mermaid"> in the static HTML: the
+// diagram source goes into the JS bundle and a React component renders it in
+// the browser. So the scan above cannot see diagrams at all, and reading the
+// source instead also lets us report file:line for the author.
+//
+// This is a structural check, not mermaid's parser -- mermaid needs a DOM even
+// to parse (`mermaid.parse()` in bare node dies on `DOMPurify.addHook`), which
+// would mean a jsdom dependency. It catches the gross mistakes; a diagram that
+// is structurally sound but has bad node syntax, or renders badly, still needs
+// a human to open the page.
+const DIAGRAM_TYPES = new Set([
+  'graph', 'flowchart', 'sequenceDiagram', 'classDiagram', 'stateDiagram',
+  'stateDiagram-v2', 'erDiagram', 'journey', 'gantt', 'pie', 'gitGraph',
+  'mindmap', 'timeline', 'quadrantChart', 'C4Context', 'sankey-beta',
+  'xychart-beta', 'block-beta', 'packet-beta', 'architecture-beta',
+  'requirementDiagram', 'zenuml', 'radar-beta', 'treemap-beta',
+]);
+
+const docsDir = resolve(here, '..', 'docs');
+const srcFiles = [];
+if (existsSync(docsDir)) {
+  (function walk(dir) {
+    for (const e of readdirSync(dir, {withFileTypes: true})) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (/\.mdx?$/.test(e.name)) srcFiles.push(p);
+    }
+  })(docsDir);
+}
+
+const mermaidProblems = [];
+let diagramCount = 0;
+for (const file of srcFiles) {
+  const lines = readFileSync(file, 'utf-8').split('\n');
+  let open = null;
+  lines.forEach((line, i) => {
+    if (open === null && /^\s*```mermaid\s*$/.test(line)) open = i;
+    else if (open !== null && /^\s*```\s*$/.test(line)) {
+      const body = lines.slice(open + 1, i);
+      const where = `${relative(resolve(here, '..', '..'), file)}:${open + 1}`;
+      diagramCount++;
+      const meaningful = body.filter((b) => b.trim() && !b.trim().startsWith('%%'));
+      if (meaningful.length === 0) {
+        mermaidProblems.push(`${where}  empty diagram`);
+      } else {
+        const type = meaningful[0].trim().split(/\s+/)[0].replace(/;$/, '');
+        if (!DIAGRAM_TYPES.has(type)) {
+          mermaidProblems.push(`${where}  unknown diagram type '${type}'`);
+        }
+        // `subgraph` is the one block that mermaid requires be closed by `end`.
+        const subgraphs = body.filter((b) => /^\s*subgraph\b/.test(b)).length;
+        const ends = body.filter((b) => /^\s*end\s*$/.test(b)).length;
+        if (subgraphs > ends) {
+          mermaidProblems.push(`${where}  ${subgraphs} subgraph vs ${ends} end`);
+        }
+      }
+      open = null;
+    }
+  });
+}
+
+console.log(`checked ${htmlFiles.length} built pages and ${diagramCount} mermaid diagrams`);
+if (findings.size === 0 && mermaidProblems.length === 0) {
   console.log('no unparsed markup found');
   process.exit(0);
+}
+
+if (mermaidProblems.length > 0) {
+  console.log('\nmermaid-structure: diagram would fail to render');
+  for (const m of mermaidProblems) console.log(`  ${m}`);
 }
 
 for (const [name, {why, hits}] of findings) {
   console.log(`\n${name}: ${why}`);
   for (const h of [...hits].sort()) console.log(`  ${h}`);
 }
-const total = [...findings.values()].reduce((n, f) => n + f.hits.size, 0);
-console.log(`\n${total} finding(s). These are rendering as raw text on the site.`);
+const total = [...findings.values()].reduce((n, f) => n + f.hits.size, 0) + mermaidProblems.length;
+console.log(`\n${total} finding(s).`);
 process.exit(1);

--- a/docs/scripts/check-rendered.mjs
+++ b/docs/scripts/check-rendered.mjs
@@ -1,0 +1,91 @@
+// Scan the built site for source syntax that failed to parse.
+//
+// Run automatically after `pnpm build` via the postbuild hook, and in CI.
+// Exits non-zero on any finding.
+//
+// Why this exists: markup Docusaurus does not understand is not an error, it
+// is *text*. `:::caution Title` (the Docusaurus v2 form, dropped in v3 in
+// favour of `:::caution[Title]`) parsed as a plain paragraph on 13 pages for
+// months, and nothing caught it -- not the build, not `onBrokenLinks: 'throw'`,
+// not a link check. The whole class is invisible unless you look at the output.
+//
+// So: strip the places source syntax is legitimate (code blocks, inline code,
+// scripts), then look for it in what is left. Anything found is markup the
+// reader is seeing raw.
+
+import {readFileSync, readdirSync, existsSync} from 'node:fs';
+import {dirname, join, relative, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const buildDir = resolve(here, '..', process.argv[2] ?? 'build');
+
+if (!existsSync(buildDir)) {
+  console.error(`no build at ${buildDir} -- run \`pnpm build\` first`);
+  process.exit(2);
+}
+
+// Where source syntax is legitimate, and so must not be scanned.
+const STRIP = [
+  /<pre\b[\s\S]*?<\/pre>/gi,
+  /<code\b[\s\S]*?<\/code>/gi,
+  /<script\b[\s\S]*?<\/script>/gi,
+  /<style\b[\s\S]*?<\/style>/gi,
+  /<noscript\b[\s\S]*?<\/noscript>/gi,
+];
+
+// Each check names markup that should never survive into visible text.
+const CHECKS = [
+  ['unparsed-admonition', /:::[a-z]*/g,
+   'admonition directive rendered as text -- v3 needs :::type[Title], not :::type Title'],
+  ['unparsed-bold', /\*\*[^*\n]{1,60}\*\*/g, 'bold markers rendered as text'],
+  ['unparsed-link', /\[[^\]\n]{1,60}\]\([^)\n]{1,80}\)/g, 'link syntax rendered as text'],
+  ['unparsed-heading', /(?:^|\n)\s*#{1,6}\s+\S/g, 'heading marker rendered as text'],
+  ['unparsed-table-row', /(?:^|\n)\s*\|[^|\n]+\|/g, 'table row rendered as text'],
+  ['doubled-list-marker', /(?:^|\n)\s*-\s+-\s+\S/g,
+   'nested one-item list -- valid CommonMark, but indents the entry one level too deep'],
+  ['visible-html-comment', /<!--/g, 'HTML comment visible to the reader'],
+  ['jsx-brace-leak', /\{\s*[a-zA-Z_$][\w.]*\s*\}/g, 'JSX expression rendered as text'],
+];
+
+const htmlFiles = [];
+(function walk(dir) {
+  for (const e of readdirSync(dir, {withFileTypes: true})) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) walk(p);
+    else if (e.name.endsWith('.html')) htmlFiles.push(p);
+  }
+})(buildDir);
+
+const unescape = (s) => s
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"')
+  .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(+d))
+  .replace(/&amp;/g, '&');
+
+const findings = new Map();
+for (const file of htmlFiles) {
+  let text = readFileSync(file, 'utf-8');
+  for (const re of STRIP) text = text.replace(re, ' ');
+  // Keep tag boundaries as line breaks so the ^-anchored checks still work.
+  text = unescape(text.replace(/<[^>]+>/g, '\n'));
+  for (const [name, re, why] of CHECKS) {
+    for (const m of text.matchAll(re)) {
+      if (!findings.has(name)) findings.set(name, {why, hits: new Set()});
+      findings.get(name).hits.add(`${relative(buildDir, file)}  ${m[0].replace(/\s+/g, ' ').trim().slice(0, 70)}`);
+    }
+  }
+}
+
+console.log(`checked ${htmlFiles.length} built pages`);
+if (findings.size === 0) {
+  console.log('no unparsed markup found');
+  process.exit(0);
+}
+
+for (const [name, {why, hits}] of findings) {
+  console.log(`\n${name}: ${why}`);
+  for (const h of [...hits].sort()) console.log(`  ${h}`);
+}
+const total = [...findings.values()].reduce((n, f) => n + f.hits.size, 0);
+console.log(`\n${total} finding(s). These are rendering as raw text on the site.`);
+process.exit(1);

--- a/docs/src/pages/changelog.md
+++ b/docs/src/pages/changelog.md
@@ -9,6 +9,10 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 ## [Unreleased]
 
 ### Added
+- `docs/scripts/check-rendered.mjs` — scans the built site for source syntax that
+  survived into visible text (unparsed admonitions, bold, links, headings, table rows,
+  doubled list markers, visible HTML comments, JSX brace leaks). Runs as a `postbuild`
+  hook and as an explicit CI step, and exits non-zero. `pnpm check-rendered`.
 - `serving/validate.sh` — 58 scenarios checked against recorded total clocks, plus md5
   checks on each `bench/examples` entry's `outputs/sim.csv` and
   `validation/summary.txt`, and a markdown report of anything that moved, ready to paste
@@ -167,6 +171,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
   the start NPU join. `ep_size` was irrelevant. The topology is now `[tp, pp, dp]`
   innermost-first, matching vLLM, with `pp` dropped when it is 1. Reported by
   [@hsule](https://github.com/hsule)
+- **Every admonition on the docs site rendered as raw text.** `:::caution Title` is
+  Docusaurus v2 syntax; v3 needs `:::caution[Title]`, and the bare form is not
+  recognised as a directive, so the block became a literal paragraph. 14 occurrences
+  across 13 pages, with no build warning. All bracketed, and
+  `docs/scripts/check-rendered.mjs` now fails the build on the whole class
 - `configs/cluster/rtx4090_tp2_instance.json` was documented as runnable in
   `configs/cluster/README.md` ("not validated", i.e. runs without ground truth) and in
   the examples table. It raises `FileNotFoundError`: only `tp1` is profiled for RTX4090.

--- a/docs/src/pages/changelog.md
+++ b/docs/src/pages/changelog.md
@@ -11,8 +11,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 ### Added
 - `docs/scripts/check-rendered.mjs` — scans the built site for source syntax that
   survived into visible text (unparsed admonitions, bold, links, headings, table rows,
-  doubled list markers, visible HTML comments, JSX brace leaks). Runs as a `postbuild`
-  hook and as an explicit CI step, and exits non-zero. `pnpm check-rendered`.
+  doubled list markers, visible HTML comments, JSX brace leaks), plus a structural
+  check on every mermaid diagram — unknown type, empty, unbalanced `subgraph`/`end` —
+  read from the source, since theme-mermaid leaves nothing in the static HTML. Runs as
+  a `postbuild` hook and as an explicit CI step, and exits non-zero.
+  `pnpm check-rendered`.
 - `serving/validate.sh` — 58 scenarios checked against recorded total clocks, plus md5
   checks on each `bench/examples` entry's `outputs/sim.csv` and
   `validation/summary.txt`, and a markdown report of anything that moved, ready to paste


### PR DESCRIPTION
Every admonition on llmservingsim.ai was rendering as raw text, and had been for months.

## The bug

`:::caution Title` is Docusaurus **v2** syntax. v3 wants the label in brackets — `:::caution[Title]` — and does not recognise the bare form as a directive, so the block becomes a literal paragraph:

```html
<p>:::caution Match <code>mem_util</code> to the real run whenever the KV cache saturates
```

14 occurrences across 13 pages, and **zero** bracketed ones in the repo, so that was all of them.

Isolated with throwaway probe pages rather than guessed: a titleless `:::note` renders; every titled form fails regardless of backticks in the title, a nested code fence, a nested table, or a missing blank line before the next heading; the bracketed form renders. So the title is the whole cause, and `caution` is still a valid type in v3.

## Why nothing caught it

The build succeeds. `onBrokenLinks: 'throw'` has no opinion. The markdown is valid CommonMark — it just means something else. **Markup this pipeline cannot parse is not an error, it is text**, so the only way to see it is to look at the output.

So the fix is not only the 14 edits. `docs/scripts/check-rendered.mjs` scans the built HTML for source syntax that survived into visible text. It strips `<pre>`/`<code>`/`<script>` first, since syntax is legitimate there, then checks for unparsed admonitions, bold, links, headings, table rows, doubled list markers, visible HTML comments and JSX brace leaks, and exits non-zero on any hit.

**Verified it fails**, because a checker that never fails is worse than none: reintroducing the bug in one page and rebuilding gives exit 1 naming `validation.html`. Across 62 pages it finds nothing else, so the admonition bug was the only instance of the class. It also covers the `- - **text**` doubled marker caught in review on #68 — valid CommonMark that renders one level too deep, which neither the build nor a body diff sees.

Wired as a `postbuild` hook so a local `pnpm build` checks too, **and** as an explicit CI step: pnpm's `enable-pre-post-scripts` default has flipped between majors, and CI should not depend on it.

## Conventions recorded

`docs/AGENTS.md` had no admonition convention at all, which is how this survived. It now has:

- The bracketed-title rule, with the failure mode spelled out.
- **A fact the code owns does not go in prose** — counts, file lists, flag sets, defaults. Prose that repeats what a script decides goes silently wrong the first time the code changes, and readers take prose as specification. Sample output and quoted examples are exempt, since a terminal block reads as a snapshot from one run. Point at the generator (`--list`, `--help`) instead of mirroring it.
- A **Checks that run on the site** section covering both build hooks.

It also now records that `src/pages/changelog.md` is **generated** by the `prebuild` hook from the repo-root `CHANGELOG.md`. It was being treated as a hand-maintained copy that had to be edited in both places; it is not, and `scripts/sync-changelog.mjs` has been doing it all along.

## Not covered

Mermaid renders client-side, so a broken diagram looks fine in the built HTML and the scanner cannot see it — 21 diagrams across 15 pages. `mermaid.parse()` in bare node dies on `DOMPurify.addHook is not a function`, so checking them needs a DOM. Stated as a known gap in `docs/AGENTS.md`: if you touch a diagram, look at the page. Adding `jsdom` would close it for syntax errors; that is a separate call.

## How to verify

```bash
cd docs && pnpm build      # postbuild runs the scanner
pnpm check-rendered        # or on its own, against an existing build
```

Rendered admonitions after the fix: 6 caution, 3 note, 2 tip, 1 each danger / info / warning = 14.
